### PR TITLE
Add metric/imperial unit toggle with centralized UnitFormatter

### DIFF
--- a/Runaway iOS/Components/CardView.swift
+++ b/Runaway iOS/Components/CardView.swift
@@ -44,8 +44,8 @@ struct CardView: View {
             return false
         }
 
-        // Must have meaningful distance (at least 0.05 miles / ~80 meters)
-        guard let distance = activity.distance, distance * 0.000621371 >= 0.05 else {
+        // Must have meaningful distance (at least 80 meters)
+        guard let distance = activity.distance, distance >= 80 else {
             return false
         }
 
@@ -113,11 +113,11 @@ struct CardView: View {
 
                     // Metrics row with modern styling
                     HStack(spacing: AppTheme.Spacing.lg) {
-                        if let distance = activity.distance, distance * 0.000621371 >= 0.1 {
+                        if let distance = activity.distance, UnitFormatter.metersToPreferredUnit(distance) >= 0.1 {
                             MetricPill(
                                 icon: AppIcons.distance,
-                                value: String(format: "%.2f", distance * 0.000621371),
-                                unit: "mi",
+                                value: UnitFormatter.formatDistance(distance, decimals: 2, includeUnit: false),
+                                unit: UnitFormatter.distanceUnitAbbreviation,
                                 color: AppTheme.Colors.accent
                             )
                         }
@@ -131,11 +131,11 @@ struct CardView: View {
                             )
                         }
 
-                        if let distance = activity.distance, let time = activity.elapsed_time, distance * 0.000621371 >= 0.1 {
+                        if let distance = activity.distance, let time = activity.elapsed_time, UnitFormatter.metersToPreferredUnit(distance) >= 0.1 {
                             MetricPill(
                                 icon: AppIcons.pace,
-                                value: calculatePace(distance: distance * 0.000621371, time: time),
-                                unit: "/mi",
+                                value: calculatePaceFromMeters(distance: distance, time: time),
+                                unit: UnitFormatter.paceUnitLabel,
                                 color: AppTheme.Colors.accent
                             )
                         }
@@ -186,7 +186,7 @@ struct CardView: View {
         }
 
         if let distance = activity.distance {
-            label += ", \(String(format: "%.2f", distance * 0.000621371)) miles"
+            label += ", \(UnitFormatter.formatDistance(distance, decimals: 2, includeUnit: true))"
         }
 
         if let time = activity.elapsed_time {
@@ -194,19 +194,29 @@ struct CardView: View {
         }
 
         if let distance = activity.distance, let time = activity.elapsed_time {
-            let pace = calculatePace(distance: distance * 0.000621371, time: time)
-            label += ", pace \(pace) per mile"
+            let pace = calculatePaceFromMeters(distance: distance, time: time)
+            label += ", pace \(pace)\(UnitFormatter.paceUnitLabel)"
         }
 
         return label
     }
-    
+
     private func calculatePace(distance: Double, time: Double) -> String {
         guard distance > 0, time > 0 else { return "--:--" }
         let paceInSeconds = time / distance
         let minutes = Int(paceInSeconds) / 60
         let seconds = Int(paceInSeconds) % 60
         return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    /// Calculate pace from distance in meters and time in seconds
+    private func calculatePaceFromMeters(distance: Double, time: Double) -> String {
+        guard distance > 0, time > 0 else { return "--:--" }
+        // Convert to minutes per mile first (internal format)
+        let miles = distance * 0.000621371
+        let minutesPerMile = (time / 60) / miles
+        // Use UnitFormatter to convert if needed
+        return UnitFormatter.formatPaceTime(minutesPerMile: minutesPerMile)
     }
 
     private func timeAgoString(from date: Date) -> String {

--- a/Runaway iOS/Components/StreamlinedTrainingComponents.swift
+++ b/Runaway iOS/Components/StreamlinedTrainingComponents.swift
@@ -302,8 +302,7 @@ struct TodaysFocusCard: View {
 
                         HStack(spacing: 8) {
                             if let distance = activity.distance {
-                                let miles = distance * 0.000621371
-                                Text(String(format: "%.1f mi", miles))
+                                Text(UnitFormatter.formatDistance(distance, decimals: 1, includeUnit: true))
                                     .font(.caption)
                                     .foregroundColor(ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary)
                             }
@@ -543,12 +542,12 @@ struct WeekProgressRow: View {
 
         // Calculate from activities only
         let completedActivities = weekEntries.filter { $0.actualActivity != nil }
-        let totalMiles = completedActivities.compactMap { entry -> Double? in
+        let totalDistance = completedActivities.compactMap { entry -> Double? in
             guard let distance = entry.actualActivity?.distance else { return nil }
-            return distance * 0.000621371
+            return UnitFormatter.metersToPreferredUnit(distance)
         }.reduce(0, +)
 
-        return (totalMiles, 0, completedActivities.count, 0)
+        return (totalDistance, 0, completedActivities.count, 0)
     }
 
     var body: some View {
@@ -572,11 +571,11 @@ struct WeekProgressRow: View {
                         Text("/")
                             .font(.caption)
                             .foregroundColor(ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textTertiary : AppTheme.Colors.LightMode.textTertiary)
-                        Text(String(format: "%.0f mi", weekStats.planned))
+                        Text(String(format: "%.0f \(UnitFormatter.distanceUnitAbbreviation)", weekStats.planned))
                             .font(.caption)
                             .foregroundColor(ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary)
                     } else {
-                        Text("mi")
+                        Text(UnitFormatter.distanceUnitAbbreviation)
                             .font(.caption)
                             .foregroundColor(ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary)
                     }
@@ -689,7 +688,7 @@ struct WeekDayActivityTile: View {
 
     private var activityDistance: Double? {
         guard let distance = entry?.actualActivity?.distance else { return nil }
-        return distance * 0.000621371 // Convert to miles
+        return UnitFormatter.metersToPreferredUnit(distance)
     }
 
     private var activityElapsedMinutes: Int? {
@@ -746,7 +745,7 @@ struct WeekDayActivityTile: View {
                         if hasActivity {
                             if isMileageFocused {
                                 if let distance = activityDistance {
-                                    Text(String(format: "%.1fmi", distance))
+                                    Text(String(format: "%.1f\(UnitFormatter.distanceUnitAbbreviation)", distance))
                                         .font(.system(size: 8, weight: .medium))
                                         .foregroundColor(iconColor)
                                 } else {
@@ -1001,7 +1000,7 @@ struct KeyMetricsGrid: View {
 
         // Use calendar week (Sunday to Saturday) for consistency
         guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: now) else {
-            return "0 mi"
+            return "0 \(UnitFormatter.distanceUnitAbbreviation)"
         }
 
         let weeklyActivities = activities.filter { activity in
@@ -1011,8 +1010,7 @@ struct KeyMetricsGrid: View {
         }
 
         let totalMeters = weeklyActivities.compactMap { $0.distance }.reduce(0, +)
-        let miles = totalMeters * 0.000621371
-        return String(format: "%.1f mi", miles)
+        return UnitFormatter.formatDistance(totalMeters, decimals: 1, includeUnit: true)
     }
 
     private var weeklyTrend: String {
@@ -1212,16 +1210,15 @@ struct CompactActivityRow: View {
         return Date(timeIntervalSince1970: interval)
     }
 
-    private var distanceMiles: Double {
-        (activity.distance ?? 0) * 0.000621371
+    private var formattedDistance: String {
+        UnitFormatter.formatDistance(activity.distance ?? 0, decimals: 1, includeUnit: true)
     }
 
     private var paceString: String {
         guard let speed = activity.average_speed, speed > 0 else { return "--:--" }
+        // Calculate minutes per mile from m/s
         let minutesPerMile = (1609.34 / speed) / 60.0
-        let minutes = Int(minutesPerMile)
-        let seconds = Int((minutesPerMile - Double(minutes)) * 60)
-        return String(format: "%d:%02d", minutes, seconds)
+        return UnitFormatter.formatPaceTime(minutesPerMile: minutesPerMile)
     }
 
     private var durationString: String {
@@ -1266,14 +1263,14 @@ struct CompactActivityRow: View {
                     .lineLimit(1)
 
                 HStack(spacing: 8) {
-                    Label(String(format: "%.1f mi", distanceMiles), systemImage: "figure.run")
+                    Label(formattedDistance, systemImage: "figure.run")
                         .font(.caption)
                         .foregroundColor(ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary)
 
                     Text("•")
                         .foregroundColor(ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textTertiary : AppTheme.Colors.LightMode.textTertiary)
 
-                    Label("\(paceString) /mi", systemImage: "speedometer")
+                    Label("\(paceString)\(UnitFormatter.paceUnitLabel)", systemImage: "speedometer")
                         .font(.caption)
                         .foregroundColor(ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary)
 
@@ -1363,8 +1360,8 @@ struct MiniWeeklyChart: View {
             }
 
             let totalMeters = weekActivities.compactMap { $0.distance }.reduce(0, +)
-            let miles = totalMeters * 0.000621371
-            weeks.append((week: 8 - weekOffset, miles: miles))
+            let distance = UnitFormatter.metersToPreferredUnit(totalMeters)
+            weeks.append((week: 8 - weekOffset, miles: distance))
         }
 
         return weeks

--- a/Runaway iOS/Models/GoalSettings.swift
+++ b/Runaway iOS/Models/GoalSettings.swift
@@ -114,10 +114,21 @@ final class GoalSettingsStore: ObservableObject {
 
 struct GoalSettingsView: View {
     @ObservedObject var store = GoalSettingsStore.shared
+    @ObservedObject var unitPreferences = UnitPreferences.shared
     @Environment(\.dismiss) var dismiss
 
     @State private var weeklyGoalText: String = ""
     @State private var monthlyGoalText: String = ""
+
+    /// Convert miles to display unit (km if metric)
+    private func toDisplayUnit(_ miles: Double) -> Double {
+        unitPreferences.isMetric ? miles * 1.60934 : miles
+    }
+
+    /// Convert from display unit back to miles
+    private func fromDisplayUnit(_ value: Double) -> Double {
+        unitPreferences.isMetric ? value / 1.60934 : value
+    }
 
     var body: some View {
         NavigationView {
@@ -126,22 +137,22 @@ struct GoalSettingsView: View {
                     HStack {
                         Text("Weekly Goal")
                         Spacer()
-                        TextField("Miles", text: $weeklyGoalText)
+                        TextField(UnitFormatter.distanceUnitName.capitalized, text: $weeklyGoalText)
                             .keyboardType(.decimalPad)
                             .multilineTextAlignment(.trailing)
                             .frame(width: 80)
-                        Text("mi")
+                        Text(UnitFormatter.distanceUnitAbbreviation)
                             .foregroundColor(.secondary)
                     }
 
                     HStack {
                         Text("Monthly Goal")
                         Spacer()
-                        TextField("Miles", text: $monthlyGoalText)
+                        TextField(UnitFormatter.distanceUnitName.capitalized, text: $monthlyGoalText)
                             .keyboardType(.decimalPad)
                             .multilineTextAlignment(.trailing)
                             .frame(width: 80)
-                        Text("mi")
+                        Text(UnitFormatter.distanceUnitAbbreviation)
                             .foregroundColor(.secondary)
                     }
                 } header: {
@@ -161,8 +172,7 @@ struct GoalSettingsView: View {
                 Section {
                     Button("Reset to Defaults") {
                         store.resetToDefaults()
-                        weeklyGoalText = String(format: "%.0f", store.settings.weeklyGoalMiles)
-                        monthlyGoalText = String(format: "%.0f", store.settings.monthlyGoalMiles)
+                        loadDisplayValues()
                     }
                     .foregroundColor(.red)
                 }
@@ -177,19 +187,26 @@ struct GoalSettingsView: View {
                 }
             }
             .onAppear {
-                weeklyGoalText = String(format: "%.0f", store.settings.weeklyGoalMiles)
-                monthlyGoalText = String(format: "%.0f", store.settings.monthlyGoalMiles)
+                loadDisplayValues()
             }
         }
     }
 
+    /// Load values from store and convert to display units
+    private func loadDisplayValues() {
+        let weeklyDisplay = toDisplayUnit(store.settings.weeklyGoalMiles)
+        let monthlyDisplay = toDisplayUnit(store.settings.monthlyGoalMiles)
+        weeklyGoalText = String(format: "%.0f", weeklyDisplay)
+        monthlyGoalText = String(format: "%.0f", monthlyDisplay)
+    }
+
     private func saveAndDismiss() {
-        // Parse and save values
+        // Parse values and convert from display unit back to miles for storage
         if let weekly = Double(weeklyGoalText), weekly > 0 {
-            store.settings.weeklyGoalMiles = weekly
+            store.settings.weeklyGoalMiles = fromDisplayUnit(weekly)
         }
         if let monthly = Double(monthlyGoalText), monthly > 0 {
-            store.settings.monthlyGoalMiles = monthly
+            store.settings.monthlyGoalMiles = fromDisplayUnit(monthly)
         }
         dismiss()
     }

--- a/Runaway iOS/Utils/UnitPreferences.swift
+++ b/Runaway iOS/Utils/UnitPreferences.swift
@@ -1,0 +1,190 @@
+//
+//  UnitPreferences.swift
+//  Runaway iOS
+//
+//  Centralized unit preferences for metric/imperial display
+//
+
+import Foundation
+import Combine
+
+/// Manages user's preferred unit system (metric/imperial)
+final class UnitPreferences: ObservableObject {
+
+    static let shared = UnitPreferences()
+
+    private let userDefaults: UserDefaults
+    private let unitKey = "preferred_distance_unit"
+
+    @Published var distanceUnit: DistanceUnit {
+        didSet {
+            save()
+        }
+    }
+
+    private init() {
+        // Use app group for widget access
+        self.userDefaults = UserDefaults(suiteName: "group.com.jackrudelic.runawayios") ?? .standard
+
+        // Load saved preference, default to miles (imperial)
+        if let savedValue = userDefaults.string(forKey: unitKey),
+           let unit = DistanceUnit(rawValue: savedValue) {
+            self.distanceUnit = unit
+        } else {
+            self.distanceUnit = .miles
+        }
+    }
+
+    private func save() {
+        userDefaults.set(distanceUnit.rawValue, forKey: unitKey)
+    }
+
+    // MARK: - Convenience Properties
+
+    var isMetric: Bool {
+        distanceUnit == .kilometers
+    }
+
+    var isImperial: Bool {
+        distanceUnit == .miles
+    }
+}
+
+// MARK: - Unit Formatter
+
+/// Centralized formatting for distances, paces, and speeds
+struct UnitFormatter {
+
+    /// Format distance from meters to user's preferred unit
+    /// - Parameters:
+    ///   - meters: Distance in meters
+    ///   - decimals: Number of decimal places (default 2)
+    ///   - includeUnit: Whether to append unit abbreviation (default true)
+    /// - Returns: Formatted distance string
+    static func formatDistance(_ meters: Double, decimals: Int = 2, includeUnit: Bool = true) -> String {
+        let unit = UnitPreferences.shared.distanceUnit
+        let value = meters / unit.metersPerUnit
+        let formatted = String(format: "%.\(decimals)f", value)
+        return includeUnit ? "\(formatted)\(unit.abbreviation)" : formatted
+    }
+
+    /// Format distance value (already in user units) with unit label
+    static func formatDistanceValue(_ value: Double, decimals: Int = 2, includeUnit: Bool = true) -> String {
+        let unit = UnitPreferences.shared.distanceUnit
+        let formatted = String(format: "%.\(decimals)f", value)
+        return includeUnit ? "\(formatted)\(unit.abbreviation)" : formatted
+    }
+
+    /// Format pace from seconds per meter to MM:SS per unit
+    /// - Parameter secondsPerMeter: Pace in seconds per meter
+    /// - Returns: Formatted pace string (e.g., "8:30/mi" or "5:17/km")
+    static func formatPace(secondsPerMeter: Double) -> String {
+        let unit = UnitPreferences.shared.distanceUnit
+        let secondsPerUnit = secondsPerMeter * unit.metersPerUnit
+
+        guard secondsPerUnit > 0 && secondsPerUnit < 60 * 60 else { return "--:--" }
+
+        let minutes = Int(secondsPerUnit) / 60
+        let seconds = Int(secondsPerUnit) % 60
+        return String(format: "%d:%02d/\(unit.abbreviation)", minutes, seconds)
+    }
+
+    /// Format pace from minutes per mile to MM:SS per user's unit
+    /// - Parameter minutesPerMile: Pace in minutes per mile (as Double, e.g., 8.5 = 8:30/mi)
+    /// - Returns: Formatted pace string
+    static func formatPace(minutesPerMile: Double) -> String {
+        guard minutesPerMile > 0 && minutesPerMile < 999 else { return "--:--" }
+
+        let unit = UnitPreferences.shared.distanceUnit
+
+        // Convert to user's preferred unit if needed
+        let minutesPerUnit: Double
+        if unit == .kilometers {
+            // Convert min/mile to min/km (divide by 1.60934)
+            minutesPerUnit = minutesPerMile / 1.60934
+        } else {
+            minutesPerUnit = minutesPerMile
+        }
+
+        let minutes = Int(minutesPerUnit)
+        let seconds = Int((minutesPerUnit - Double(minutes)) * 60)
+        return String(format: "%d:%02d/\(unit.abbreviation)", minutes, seconds)
+    }
+
+    /// Format pace with just the time portion (no unit suffix)
+    static func formatPaceTime(minutesPerMile: Double) -> String {
+        guard minutesPerMile > 0 && minutesPerMile < 999 else { return "--:--" }
+
+        let unit = UnitPreferences.shared.distanceUnit
+
+        let minutesPerUnit: Double
+        if unit == .kilometers {
+            minutesPerUnit = minutesPerMile / 1.60934
+        } else {
+            minutesPerUnit = minutesPerMile
+        }
+
+        let minutes = Int(minutesPerUnit)
+        let seconds = Int((minutesPerUnit - Double(minutes)) * 60)
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    /// Format speed from meters per second
+    /// - Parameter metersPerSecond: Speed in m/s
+    /// - Returns: Formatted speed string (e.g., "7.5mph" or "12.1km/h")
+    static func formatSpeed(_ metersPerSecond: Double) -> String {
+        let unit = UnitPreferences.shared.distanceUnit
+
+        let speed: Double
+        let suffix: String
+
+        if unit == .miles {
+            speed = metersPerSecond * 2.23694 // m/s to mph
+            suffix = "mph"
+        } else {
+            speed = metersPerSecond * 3.6 // m/s to km/h
+            suffix = "km/h"
+        }
+
+        return String(format: "%.1f%@", speed, suffix)
+    }
+
+    /// Format speed value only (no unit suffix)
+    static func formatSpeedValue(_ metersPerSecond: Double) -> String {
+        let unit = UnitPreferences.shared.distanceUnit
+
+        let speed: Double
+        if unit == .miles {
+            speed = metersPerSecond * 2.23694
+        } else {
+            speed = metersPerSecond * 3.6
+        }
+
+        return String(format: "%.1f", speed)
+    }
+
+    /// Get the speed unit label
+    static var speedUnitLabel: String {
+        UnitPreferences.shared.distanceUnit == .miles ? "mph" : "km/h"
+    }
+
+    /// Get the pace unit label (e.g., "/mi" or "/km")
+    static var paceUnitLabel: String {
+        "/\(UnitPreferences.shared.distanceUnit.abbreviation)"
+    }
+
+    /// Get the distance unit abbreviation
+    static var distanceUnitAbbreviation: String {
+        UnitPreferences.shared.distanceUnit.abbreviation
+    }
+
+    /// Get the full distance unit name
+    static var distanceUnitName: String {
+        UnitPreferences.shared.distanceUnit.displayName.lowercased()
+    }
+
+    /// Convert meters to user's preferred unit (value only)
+    static func metersToPreferredUnit(_ meters: Double) -> Double {
+        meters / UnitPreferences.shared.distanceUnit.metersPerUnit
+    }
+}

--- a/Runaway iOS/Views/ActiveRecordingView.swift
+++ b/Runaway iOS/Views/ActiveRecordingView.swift
@@ -246,15 +246,15 @@ struct ActiveRecordingView: View {
             // Primary metrics row (Distance and Pace)
             HStack(spacing: 20) {
                 primaryMetricCard(
-                    value: String(format: "%.2f", recordingService.gpsService.totalDistanceMiles),
-                    unit: "mi",
+                    value: UnitFormatter.formatDistance(recordingService.gpsService.totalDistance, decimals: 2, includeUnit: false),
+                    unit: UnitFormatter.distanceUnitAbbreviation,
                     label: "Distance",
                     icon: "point.topleft.down.to.point.bottomright.curvepath"
                 )
 
                 primaryMetricCard(
-                    value: formatPace(recordingService.gpsService.currentPace),
-                    unit: "/mi",
+                    value: UnitFormatter.formatPaceTime(minutesPerMile: recordingService.gpsService.currentPace),
+                    unit: UnitFormatter.paceUnitLabel,
                     label: "Pace",
                     icon: "speedometer"
                 )
@@ -263,13 +263,13 @@ struct ActiveRecordingView: View {
             // Secondary metrics row
             HStack(spacing: 12) {
                 secondaryMetricCard(
-                    value: formatPace(recordingService.gpsService.averagePace),
+                    value: UnitFormatter.formatPaceTime(minutesPerMile: recordingService.gpsService.averagePace),
                     label: "Avg Pace"
                 )
 
                 secondaryMetricCard(
-                    value: String(format: "%.1f", recordingService.gpsService.currentSpeed * 2.237),
-                    label: "Speed (mph)"
+                    value: UnitFormatter.formatSpeedValue(recordingService.gpsService.currentSpeed),
+                    label: "Speed (\(UnitFormatter.speedUnitLabel))"
                 )
 
                 if needsGPS {

--- a/Runaway iOS/Views/PostRecordingView.swift
+++ b/Runaway iOS/Views/PostRecordingView.swift
@@ -203,8 +203,8 @@ struct PostRecordingView: View {
             LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: 16) {
                 SummaryMetricCard(
                     title: "Distance",
-                    value: String(format: "%.2f", recordingService.gpsService.totalDistanceMiles),
-                    unit: "miles",
+                    value: UnitFormatter.formatDistance(recordingService.gpsService.totalDistance, decimals: 2, includeUnit: false),
+                    unit: UnitFormatter.distanceUnitName,
                     icon: "road.lanes",
                     color: .blue
                 )
@@ -219,16 +219,16 @@ struct PostRecordingView: View {
 
                 SummaryMetricCard(
                     title: "Avg Pace",
-                    value: formatPace(recordingService.gpsService.averagePace),
-                    unit: "/mile",
+                    value: UnitFormatter.formatPaceTime(minutesPerMile: recordingService.gpsService.averagePace),
+                    unit: UnitFormatter.paceUnitLabel,
                     icon: "speedometer",
                     color: .orange
                 )
 
                 SummaryMetricCard(
                     title: "Avg Speed",
-                    value: String(format: "%.1f", recordingService.gpsService.averageSpeed * 2.237),
-                    unit: "mph",
+                    value: UnitFormatter.formatSpeedValue(recordingService.gpsService.averageSpeed),
+                    unit: UnitFormatter.speedUnitLabel,
                     icon: "gauge.high",
                     color: .purple
                 )

--- a/Runaway iOS/Views/SettingsView.swift
+++ b/Runaway iOS/Views/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var stravaService = StravaService()
     @StateObject private var garminService = GarminService()
+    @ObservedObject private var unitPreferences = UnitPreferences.shared
     @State private var showingStravaSheet = false
     @State private var showingGarminSheet = false
     @State private var showingDisconnectAlert = false
@@ -161,6 +162,9 @@ struct SettingsView: View {
 
             // Theme Toggle
             ThemeToggleRow(themeManager: themeManager, colors: colors)
+
+            // Unit Toggle
+            UnitToggleRow(unitPreferences: unitPreferences, colors: colors)
 
             SettingsRow(
                 icon: "bell",
@@ -962,6 +966,77 @@ struct ThemeToggleRow: View {
         .cornerRadius(AppTheme.CornerRadius.large)
         .shadow(
             color: themeManager.isDarkMode ? Color.black.opacity(0.3) : Color.black.opacity(0.08),
+            radius: 4,
+            x: 0,
+            y: 2
+        )
+    }
+}
+
+// MARK: - Unit Toggle Row
+struct UnitToggleRow: View {
+    @ObservedObject var unitPreferences: UnitPreferences
+    let colors: (background: Color, cardBg: Color, textPrimary: Color, textSecondary: Color)
+
+    var body: some View {
+        HStack(spacing: AppTheme.Spacing.sm) {
+            // Icon
+            ZStack {
+                Circle()
+                    .fill(AppTheme.Colors.accent.opacity(0.2))
+                    .frame(width: 40, height: 40)
+
+                Image(systemName: "ruler")
+                    .font(.title3)
+                    .foregroundColor(AppTheme.Colors.accent)
+            }
+
+            // Content
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Units")
+                    .font(AppTheme.Typography.body.weight(.medium))
+                    .foregroundColor(colors.textPrimary)
+
+                Text(unitPreferences.isImperial ? "Imperial (mi, mph)" : "Metric (km, km/h)")
+                    .font(AppTheme.Typography.caption)
+                    .foregroundColor(colors.textSecondary)
+            }
+
+            Spacer()
+
+            // Unit Toggle
+            HStack(spacing: AppTheme.Spacing.xs) {
+                ForEach(DistanceUnit.allCases, id: \.self) { unit in
+                    Button(action: {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            unitPreferences.distanceUnit = unit
+                        }
+                    }) {
+                        Text(unit.abbreviation)
+                            .font(AppTheme.Typography.caption.weight(.medium))
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 6)
+                            .background(
+                                unitPreferences.distanceUnit == unit
+                                    ? AppTheme.Colors.accent
+                                    : colors.cardBg
+                            )
+                            .foregroundColor(
+                                unitPreferences.distanceUnit == unit
+                                    ? .white
+                                    : colors.textSecondary
+                            )
+                            .cornerRadius(8)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+            }
+        }
+        .padding(AppTheme.Spacing.md)
+        .background(colors.cardBg)
+        .cornerRadius(AppTheme.CornerRadius.large)
+        .shadow(
+            color: ThemeManager.shared.isDarkMode ? Color.black.opacity(0.3) : Color.black.opacity(0.08),
             radius: 4,
             x: 0,
             y: 2

--- a/RunawayWidget/RunawayWidget.swift
+++ b/RunawayWidget/RunawayWidget.swift
@@ -10,11 +10,47 @@ import SwiftUI
 import Charts
 import AppIntents
 
+// MARK: - Widget Unit Helper (reads from shared UserDefaults)
+
+struct WidgetUnitHelper {
+    private static let userDefaults = UserDefaults(suiteName: "group.com.jackrudelic.runawayios")
+    private static let unitKey = "preferred_distance_unit"
+
+    /// Check if user prefers metric units
+    static var isMetric: Bool {
+        guard let savedValue = userDefaults?.string(forKey: unitKey) else {
+            return false // Default to imperial (miles)
+        }
+        return savedValue == "kilometers"
+    }
+
+    /// Distance unit abbreviation
+    static var unitAbbreviation: String {
+        isMetric ? "km" : "mi"
+    }
+
+    /// Distance unit full name
+    static var unitName: String {
+        isMetric ? "Kilometers" : "Miles"
+    }
+
+    /// Convert miles to user's preferred unit
+    static func convertFromMiles(_ miles: Double) -> Double {
+        isMetric ? miles * 1.60934 : miles
+    }
+
+    /// Format distance value with unit
+    static func formatDistance(_ miles: Double, decimals: Int = 1) -> String {
+        let value = convertFromMiles(miles)
+        return String(format: "%.\(decimals)f", value)
+    }
+}
+
 struct Day: Identifiable {
     var name: String
     var type: String
     var minutes: Double = 0
-    var miles: Double = 0
+    var miles: Double = 0 // Stored in miles, converted for display
     var id = UUID()
 }
 
@@ -125,17 +161,22 @@ struct BarChart: View {
 
 
 struct PieChartView: View {
-    
-    var current: Double
+
+    var current: Double // Value in miles (will be converted for display if metric)
     var goalRemaining: Double
     var color: Color
-    
+
+    /// Display value converted to user's preferred unit
+    private var displayValue: Double {
+        WidgetUnitHelper.convertFromMiles(current)
+    }
+
     var data: [(type: String, amount: Double)] {
         [(type: "current", amount: current),
          (type: "goal", amount: goalRemaining)
         ]
     }
-    
+
     var body: some View {
         Chart(data, id: \.type) { dataItem in
             SectorMark(angle: .value("Type", dataItem.amount),
@@ -149,7 +190,7 @@ struct PieChartView: View {
         .chartBackground { chartProxy in
             GeometryReader { geometry in
                 let frame = geometry[chartProxy.plotFrame!]
-                Text(String(format: "%.1f", current)).font(.system( size: 10, weight: .heavy)).position(x: frame.midX, y: frame.midY)
+                Text(String(format: "%.1f", displayValue)).font(.system( size: 10, weight: .heavy)).position(x: frame.midX, y: frame.midY)
             }
         }
     }
@@ -401,6 +442,11 @@ struct RunawayWidgetEntryView : View {
         return "Loading..."
     }
     
+    /// Year total converted to preferred unit
+    private var yearTotalDisplay: Double {
+        WidgetUnitHelper.convertFromMiles(entry.miles)
+    }
+
     var body: some View {
         VStack (alignment: .leading) {
             HStack(alignment: .bottom){
@@ -413,17 +459,17 @@ struct RunawayWidgetEntryView : View {
             }
             HStack(alignment: .bottom){
                 VStack(alignment: .leading){
-                    Text("\(String(Calendar.current.component(.year, from: Date()))) Miles:").font(.system(size: 14, weight: .semibold)).foregroundColor(.white).padding(.bottom,1)
-                    Text(String(entry.miles.thousandsOfMiles)).font(.custom("Futura-CondensedExtraBold", fixedSize: 40)).foregroundColor(.white).tracking(-1)
+                    Text("\(String(Calendar.current.component(.year, from: Date()))) \(WidgetUnitHelper.unitName):").font(.system(size: 14, weight: .semibold)).foregroundColor(.white).padding(.bottom,1)
+                    Text(yearTotalDisplay.thousandsOfMiles).font(.custom("Futura-CondensedExtraBold", fixedSize: 40)).foregroundColor(.white).tracking(-1)
                 }.frame(minWidth: 140).padding(.bottom,8)
                 Spacer()
                 VStack{
                     PieChartView(current: weeklyMileage, goalRemaining: max(0, entry.weeklyGoal - weeklyMileage), color: Color(red: 0.2, green: 0.6, blue: 1.0)).padding(.bottom,2)
-                    Text("Weekly Miles").font(.system(size: 8, weight: .heavy)).foregroundColor(.white)
+                    Text("Weekly \(WidgetUnitHelper.unitAbbreviation)").font(.system(size: 8, weight: .heavy)).foregroundColor(.white)
                 }.padding(.bottom,8)
                 VStack{
                     PieChartView(current: entry.monthlyMiles, goalRemaining: max(0, entry.monthlyGoal - entry.monthlyMiles), color: Color(red: 0.4, green: 0.8, blue: 0.4)).padding(.bottom,2)
-                    Text("Monthly Miles").font(.system(size: 8, weight: .heavy)).foregroundColor(.white)
+                    Text("Monthly \(WidgetUnitHelper.unitAbbreviation)").font(.system(size: 8, weight: .heavy)).foregroundColor(.white)
                 }.padding(.bottom,8)
             }.padding(.top, 16)
             HStack(alignment: .bottom){


### PR DESCRIPTION
- Add UnitPreferences singleton for persisting unit preference (miles/km)
- Add UnitFormatter utility with static methods for formatting distances, paces, speeds
- Add unit toggle row in Settings with mi/km buttons
- Update ActiveRecordingView to use UnitFormatter for live metrics
- Update PostRecordingView summary metrics to use UnitFormatter
- Update CardView feed cards to use dynamic unit display
- Update StreamlinedTrainingComponents (weekly stats, activity tiles, etc.)
- Preference persists via app group UserDefaults for widget access
- Default is imperial (miles)