### PR TITLE
Feature/ux design system

### DIFF
--- a/.claude/UX-AUDIT-2026-01.md
+++ b/.claude/UX-AUDIT-2026-01.md
@@ -1,0 +1,544 @@
+# UX Design Principles Audit Report
+**Date:** January 2026
+**Branch:** `feature/ux-design-system`
+**Auditor:** Claude Code
+
+---
+
+## Executive Summary
+
+This audit evaluates Runaway iOS views against the UX Design Principles documented in `/.claude/UX-DESIGN-PRINCIPLES.md`. The app demonstrates **strong foundational design** with notable strengths in theme consistency and typography hierarchy. However, there are **critical gaps** in progressive disclosure, touch target sizing for motion contexts, and dashboard-level information architecture.
+
+| View | Score | Priority Issues |
+|------|-------|-----------------|
+| ActiveRecordingView | 7.2/10 | Touch targets, cognitive load |
+| ActivitiesView (Dashboard) | 6.5/10 | Missing Tier 2 stats, no progressive disclosure |
+| Widget | 9.0/10 | Excellent Tier 1 implementation |
+| PostRecordingView | 9.2/10 | Exemplary (see previous session) |
+
+---
+
+## Detailed View Audits
+
+---
+
+### 1. ActiveRecordingView.swift
+
+**File:** `Runaway iOS/Views/ActiveRecordingView.swift`
+**Lines:** 482
+**Context:** Primary view during active workout recording
+
+#### Principle Compliance Analysis
+
+##### Three-Tier Information Architecture
+
+| Tier | Implementation | Assessment |
+|------|---------------|------------|
+| **Tier 1 (Glance)** | Timer at 64pt (`line 236`) | **GOOD** - Large, readable, monospacedDigit |
+| **Tier 2 (Quick View)** | Distance/Pace cards + secondary metrics | **MIXED** - Primary cards good, secondary overwhelms |
+| **Tier 3 (Deep Dive)** | None available | **N/A** - Appropriate for recording context |
+
+**Issues Found:**
+
+1. **Secondary metrics grid shows 5 values simultaneously** (`lines 264-281`):
+   - Avg Pace
+   - Speed
+   - GPS Points (when GPS activity)
+
+   Combined with 2 primary metrics (Distance, Pace), users see **7 data points** while running. UX Principles state: "reduced cognitive load - no decisions required" for motion context.
+
+2. **No progressive disclosure** - All metrics visible at once, no tap-to-expand functionality.
+
+##### Touch Targets (Motion Context)
+
+**Principle requirement:** 60pt minimum, 80pt+ preferred during active runs
+
+| Element | Current Size | Location | Assessment |
+|---------|-------------|----------|------------|
+| Pause/Resume button | 70x70pt | `line 363` | **BELOW STANDARD** - Should be 80pt+ |
+| Stop button | 70x70pt | `line 384` | **BELOW STANDARD** - Should be 80pt+ |
+| Activity type badge | ~44pt height | `lines 148-161` | **OK** - Not interactive during recording |
+| Secondary metric cards | ~40pt height | `lines 315-332` | **NOT TAPPABLE** - No interaction |
+
+**Critical Issue:** Control buttons at 70x70pt are **10pt below the 80pt+ recommendation** for active motion context. During runs with sweaty/gloved fingers, this increases tap failure rate.
+
+##### Context Adaptation
+
+**Strengths:**
+- Auto-pause indicator (`lines 336-351`) - Excellent contextual feedback
+- Recording state indicator with pulse animation (`lines 166-181`)
+- Activity-specific icon and color (`lines 35-59`)
+- Timer updates via dedicated `TimerUpdateManager` (`line 22`)
+
+**Gaps:**
+- No simplified "racing mode" with minimal UI
+- No haptic feedback on button presses (principle: "Haptic feedback for confirmations")
+- No adaptive layout for different device sizes
+
+##### Typography Compliance
+
+| Element | Current | Principle Standard | Status |
+|---------|---------|-------------------|--------|
+| Timer | 64pt bold rounded | 34-48pt headline | **EXCEEDS** (appropriate for hero) |
+| Primary metric value | 32pt bold | 24-32pt primary stat | **COMPLIANT** |
+| Primary metric label | caption (12pt) | 13-15pt caption | **COMPLIANT** |
+| Secondary metric value | headline (~17pt) | 17-20pt secondary | **COMPLIANT** |
+| Secondary metric label | caption2 (11pt) | 11-13pt caption | **COMPLIANT** |
+
+##### Spacing Analysis
+
+Current implementation uses:
+- `spacing: 24` between timer and icon (`line 206`)
+- `spacing: 16` in metrics grid (`line 245`)
+- `spacing: 20` between primary cards (`line 247`)
+- `spacing: 12` between secondary cards (`line 264`)
+- `padding: 20` horizontal (`lines 283, 351, 395`)
+
+**Assessment:** Spacing is consistent with principle's 8pt base system (multiples of 4/8).
+
+#### Specific Code Issues
+
+```swift
+// Line 363 - Touch target too small for motion context
+.frame(width: 70, height: 70)
+
+// SHOULD BE:
+.frame(width: 80, height: 80)
+```
+
+```swift
+// Lines 264-281 - Information overload
+// Shows: Avg Pace, Speed, GPS Points all at once
+
+// RECOMMENDATION: Progressive disclosure
+// Show only 1-2 secondary metrics, tap for more
+```
+
+#### Recommended Changes
+
+| Priority | Change | Lines Affected |
+|----------|--------|----------------|
+| **P0** | Increase control buttons to 80x80pt | 363, 384 |
+| **P1** | Add haptic feedback on button press | 358, 377 |
+| **P1** | Reduce visible secondary metrics to 2 | 264-281 |
+| **P2** | Add tap-to-expand for secondary metrics | 315-332 |
+| **P2** | Create simplified "focus mode" option | New feature |
+
+---
+
+### 2. ActivitiesView.swift (Dashboard)
+
+**File:** `Runaway iOS/Views/ActivitiesView.swift`
+**Lines:** 188
+**Context:** Main dashboard/feed showing activity list
+
+#### Principle Compliance Analysis
+
+##### Three-Tier Information Architecture
+
+| Tier | Implementation | Assessment |
+|------|---------------|------------|
+| **Tier 1 (Glance)** | ActivityCommitmentCard | **PARTIAL** - Only shows commitment, not stats |
+| **Tier 2 (Quick View)** | Activity list | **MISSING** - No summary statistics |
+| **Tier 3 (Deep Dive)** | ActivityDetailView on tap | **GOOD** - Proper drill-down |
+
+**Critical Gap:** The dashboard **completely lacks Tier 2 summary statistics**. Per UX Principles:
+
+> "Quick View (App home): 3-5 primary stats with trend indicators"
+
+Current dashboard shows:
+- ActivityCommitmentCard (commitment tracking only)
+- List of activity cards
+
+**Missing elements:**
+- Weekly mileage total
+- Number of activities this week
+- Current streak
+- Progress toward weekly/monthly goals
+- Trend indicators (up/down arrows)
+
+##### Dashboard Layout Analysis
+
+```swift
+// Lines 67-94 - Current structure
+ScrollView {
+    LazyVStack(spacing: AppTheme.Spacing.md) {
+        // Only ActivityCommitmentCard at top
+        ActivityCommitmentCard()
+            .padding(.horizontal, AppTheme.Spacing.md)
+
+        // Then immediately into activity list
+        ForEach(dataManager.activities.indices, id: \.self) { index in
+            CardView(...)
+        }
+    }
+}
+```
+
+**Issue:** No "WeeklyStatsCard" or "QuickStatsSection" between commitment and activities.
+
+##### Progressive Disclosure
+
+**Current State:** None implemented
+
+- Activity cards are static (no expand/collapse)
+- No expandable sections
+- All cards same priority visually
+
+**Principle Violation:** "Progressive Disclosure in Charts: Start with simplified trend view, tap to reveal detailed breakdowns"
+
+##### Touch Targets
+
+| Element | Current Size | Assessment |
+|---------|-------------|------------|
+| FAB (Floating Action Button) | 56pt (`AppTheme.Layout.fabSize`) | **COMPLIANT** - 56pt is good for stationary |
+| Activity cards | Full width, implicit | **COMPLIANT** - Easy to tap |
+| Refresh button | 44pt (toolbar) | **COMPLIANT** - Apple standard |
+
+##### Empty State Analysis
+
+```swift
+// Lines 54-64 - Empty state
+ScrollView {
+    VStack(spacing: AppTheme.Spacing.lg) {
+        ActivityCommitmentCard()
+        EmptyActivitiesView()
+    }
+}
+```
+
+**Issue:** Empty state only shows generic message. Should show:
+- Weekly/monthly goal progress (even at 0)
+- Motivational context
+- Quick-start suggestions
+
+##### Recommendations
+
+| Priority | Change | Impact |
+|----------|--------|--------|
+| **P0** | Add WeeklyStatsCard above activity list | Implements Tier 2 |
+| **P0** | Show: Weekly miles, run count, streak | Core dashboard metrics |
+| **P1** | Add trend indicators to stats | Visual feedback |
+| **P1** | Make stats card tappable for details | Progressive disclosure |
+| **P2** | Improve empty state with goals | Better onboarding UX |
+
+**Proposed WeeklyStatsCard Structure:**
+
+```swift
+// NEW COMPONENT NEEDED
+struct WeeklyStatsCard: View {
+    // Tier 2 metrics:
+    // - This week: X.X mi (trend arrow)
+    // - Activities: N (trend arrow)
+    // - Streak: N days
+    // - Goal progress: X% of Y mi
+}
+```
+
+---
+
+### 3. RunawayWidget.swift
+
+**File:** `RunawayWidget/RunawayWidget.swift`
+**Lines:** 548
+**Context:** Home screen widget for glanceable stats
+
+#### Principle Compliance Analysis
+
+##### Three-Tier Architecture (Tier 1 Focus)
+
+**Assessment: EXCELLENT**
+
+The widget is a **model implementation** of Tier 1 (Glance) principles:
+
+| Element | Implementation | Principle Alignment |
+|---------|---------------|---------------------|
+| Hero metric | Year total at 40pt Futura Condensed (`line 463`) | **PERFECT** - Single key metric, largest |
+| Secondary visual | Weekly bar chart (`line 458`) | **GOOD** - Visual, not text-heavy |
+| Tertiary | Pie charts for goals (`lines 467-473`) | **GOOD** - Progress at a glance |
+| Context | Location name (`line 453`) | **GOOD** - Provides context |
+
+##### Typography Analysis
+
+```swift
+// Line 463 - Hero metric
+Text(yearTotalDisplay.thousandsOfMiles)
+    .font(.custom("Futura-CondensedExtraBold", fixedSize: 40))
+
+// Line 462 - Label
+.font(.system(size: 14, weight: .semibold))
+
+// Lines 468, 472 - Pie chart labels
+.font(.system(size: 8, weight: .heavy))
+```
+
+**Assessment:** Custom Futura font for hero creates visual distinction. However, 8pt labels for pie charts are **below accessibility guidelines** (11pt minimum recommended).
+
+##### Unit Support
+
+```swift
+// Lines 15-47 - WidgetUnitHelper
+static var isMetric: Bool {
+    guard let savedValue = userDefaults?.string(forKey: unitKey) else {
+        return false // Default to imperial (miles)
+    }
+    return savedValue == "kilometers"
+}
+```
+
+**EXCELLENT:** Respects user's distance unit preference throughout widget.
+
+##### Empty State Messaging
+
+```swift
+// Lines 84-97 - Empty state messages
+private var emptyStateMessages: [String] {
+    [
+        "You better be lacing up your sneakers...",
+        "Those running shoes are looking lonely 👟",
+        "Time to turn those couch miles into real miles!",
+        // ...
+    ]
+}
+```
+
+**Issue:** Messages are **judgmental/shaming** rather than encouraging. Per UX principles, empty states should be motivational, not guilt-inducing.
+
+**Recommended alternatives:**
+- "Ready for your first run this week?"
+- "Your week is wide open - time to write your story!"
+- "Every mile starts with the first step"
+
+##### Visual Density
+
+| Component | Size | Assessment |
+|-----------|------|------------|
+| Bar chart | Flexible height | **GOOD** - Scales with widget |
+| Pie charts | 65pt height (`line 189`) | **ADEQUATE** - Could be larger |
+| Year total | 40pt font | **EXCELLENT** - Highly readable |
+| Labels | 8-14pt | **MIXED** - Some too small |
+
+##### Data Refresh
+
+```swift
+// Lines 231-232 - Timeline refresh
+for hourOffset in 0 ..< 5 {
+    let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+```
+
+**GOOD:** Refreshes every hour with 5-entry timeline. Appropriate for fitness data that changes infrequently.
+
+##### Recommendations
+
+| Priority | Change | Lines |
+|----------|--------|-------|
+| **P1** | Replace judgmental empty messages | 84-97 |
+| **P2** | Increase pie chart label font to 10pt | 468, 472 |
+| **P2** | Add goal achievement indicator (checkmark when met) | New |
+| **P3** | Consider tap actions for iOS 17+ widgets | New |
+
+---
+
+## Cross-View Consistency Analysis
+
+### Design System Compliance
+
+#### AppTheme Usage
+
+The codebase has a **comprehensive theme system** in `Utils/Theme.swift` (833 lines) that defines:
+
+- Colors (with Light/Dark mode variants)
+- Typography (SF Pro Rounded, 15 size variants)
+- Spacing (8pt base system: xxs=2, xs=4, sm=8, md=12, lg=16, xl=20, xxl=24)
+- Corner radius (tiny=4 to massive=32)
+- Shadows (5 levels + colored glows)
+- Layout constants (FAB=56pt, icons, cards)
+
+**Consistency Check:**
+
+| View | Uses AppTheme.Spacing | Uses AppTheme.Typography | Uses AppTheme.Colors |
+|------|----------------------|-------------------------|---------------------|
+| ActiveRecordingView | Partial (hardcoded 16, 20, 24) | Partial (system fonts inline) | Yes (via themeManager) |
+| ActivitiesView | Yes | Yes | Yes |
+| Widget | No (standalone) | No (custom fonts) | No (hardcoded) |
+
+**Issue:** ActiveRecordingView uses hardcoded spacing values instead of `AppTheme.Spacing` constants:
+
+```swift
+// Line 245 - Hardcoded
+VStack(spacing: 16)
+
+// SHOULD BE:
+VStack(spacing: AppTheme.Spacing.lg)
+```
+
+#### Touch Target Standards
+
+| Context | Principle | AppTheme.Layout | Actual Implementation |
+|---------|-----------|-----------------|----------------------|
+| Standard | 44pt | Not defined | Varies |
+| Pre-activity | 56pt | fabSize=56 | FAB correct |
+| Active run | 80pt | Not defined | 70pt (non-compliant) |
+
+**Gap:** `AppTheme.Layout` lacks context-aware touch target constants.
+
+**Recommendation:** Add to Theme.swift:
+
+```swift
+struct TouchTargets {
+    static let standard: CGFloat = 44
+    static let preActivity: CGFloat = 56
+    static let activeRun: CGFloat = 80
+    static let minimum: CGFloat = 44
+}
+```
+
+### Metric Card Pattern Analysis
+
+#### Current Implementations
+
+**1. ActiveRecordingView - `primaryMetricCard` (lines 286-313)**
+```swift
+private func primaryMetricCard(value: String, unit: String, label: String, icon: String) -> some View {
+    VStack(spacing: 8) {
+        HStack(alignment: .lastTextBaseline, spacing: 4) {
+            Text(value).font(.system(size: 32, weight: .bold, design: .rounded))
+            Text(unit).font(.subheadline)
+        }
+        HStack(spacing: 4) {
+            Image(systemName: icon).font(.caption)
+            Text(label).font(.caption)
+        }
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 16)
+    .background(RoundedRectangle(cornerRadius: 16).fill(...))
+}
+```
+
+**2. ActiveRecordingView - `secondaryMetricCard` (lines 315-332)**
+```swift
+private func secondaryMetricCard(value: String, label: String) -> some View {
+    VStack(spacing: 4) {
+        Text(value).font(.headline)
+        Text(label).font(.caption2)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 12)
+    .background(RoundedRectangle(cornerRadius: 12).fill(...))
+}
+```
+
+**Assessment:** These are **local implementations**, not reusable components. Per UX Principles:
+
+> "Metric Card (Reusable): Every metric display should use a consistent card pattern"
+
+**Recommendation:** Create unified `MetricCard` component:
+
+```swift
+// Proposed: Components/MetricCard.swift
+struct MetricCard: View {
+    enum Size { case compact, standard, large }
+    enum Context { case stationary, active }
+
+    let value: String
+    let label: String
+    var unit: String? = nil
+    var icon: String? = nil
+    var trend: TrendIndicator? = nil
+    var size: Size = .standard
+    var context: Context = .stationary
+}
+```
+
+---
+
+## Priority Improvement Matrix
+
+### P0 - Critical (Affects core UX)
+
+| Issue | View | Effort | Impact |
+|-------|------|--------|--------|
+| Add WeeklyStatsCard to dashboard | ActivitiesView | Medium | High - Implements Tier 2 |
+| Increase recording control buttons to 80pt | ActiveRecordingView | Low | High - Accessibility |
+
+### P1 - Important (Improves experience)
+
+| Issue | View | Effort | Impact |
+|-------|------|--------|--------|
+| Add haptic feedback to recording controls | ActiveRecordingView | Low | Medium |
+| Reduce visible secondary metrics | ActiveRecordingView | Low | Medium |
+| Replace widget empty state messages | Widget | Low | Medium |
+| Create reusable MetricCard component | Global | Medium | High (consistency) |
+
+### P2 - Enhancement (Polish)
+
+| Issue | View | Effort | Impact |
+|-------|------|--------|--------|
+| Add tap-to-expand for metrics | ActiveRecordingView | Medium | Medium |
+| Add touch target constants to AppTheme | Theme.swift | Low | Medium |
+| Standardize spacing to use AppTheme | ActiveRecordingView | Low | Low |
+| Increase widget pie chart labels | Widget | Low | Low |
+
+### P3 - Future (Nice to have)
+
+| Issue | View | Effort | Impact |
+|-------|------|--------|--------|
+| Add "focus mode" for minimal recording UI | ActiveRecordingView | High | Medium |
+| Add widget tap actions (iOS 17+) | Widget | Medium | Low |
+| Implement smart metric prioritization by training phase | Global | High | High |
+
+---
+
+## Implementation Recommendations
+
+### Phase 1: Critical Fixes (1-2 days)
+
+1. **Create WeeklyStatsCard component**
+   - Shows: This week miles, activity count, streak, goal %
+   - Add to ActivitiesView above activity list
+   - Make tappable for detailed weekly view
+
+2. **Fix recording touch targets**
+   - Update control buttons from 70pt to 80pt
+   - Add `UIImpactFeedbackGenerator` on button press
+
+### Phase 2: Metric Card System (2-3 days)
+
+1. **Create unified MetricCard component**
+   - Support compact/standard/large sizes
+   - Support trend indicators
+   - Support tap-to-expand behavior
+   - Context-aware sizing (active vs stationary)
+
+2. **Refactor existing metric displays**
+   - ActiveRecordingView primary/secondary cards
+   - PostRecordingView CompactMetricCard
+   - ActivityDetailView metric grid
+
+### Phase 3: Progressive Disclosure (3-5 days)
+
+1. **Add expansion behavior to metrics**
+   - Tap metric to see historical context
+   - Show "vs average" and "vs goal" comparisons
+
+2. **Implement training phase awareness**
+   - Detect base building vs race prep vs recovery
+   - Surface relevant metrics based on phase
+
+---
+
+## Conclusion
+
+Runaway iOS has a **solid design foundation** with excellent theme consistency and good typography choices. The primary gaps are:
+
+1. **Missing Tier 2 dashboard stats** - Users must drill into activities to see summary data
+2. **Suboptimal touch targets during recording** - 70pt vs recommended 80pt for motion context
+3. **No progressive disclosure** - All metrics shown at once, no expansion behavior
+4. **Inconsistent metric card patterns** - Multiple implementations instead of unified component
+
+Addressing P0 and P1 items would significantly improve the app's adherence to the UX Design Principles and create a more glanceable, context-aware experience.
+
+---
+
+*Audit complete. See `/.claude/UX-DESIGN-PRINCIPLES.md` for the principles referenced in this report.*

--- a/.claude/UX-DESIGN-PRINCIPLES.md
+++ b/.claude/UX-DESIGN-PRINCIPLES.md
@@ -1,0 +1,185 @@
+# Runaway UX Design Principles
+
+**Status:** Active - These principles MUST be considered for all UI/UX decisions.
+
+---
+
+## Core Philosophy: Glanceable Data with Progressive Disclosure
+
+Runaway prioritizes **scannable information architecture** with **adaptive visual density** based on user context. Information should be instantly comprehensible at a glance, with depth available on demand.
+
+---
+
+## Three-Tier Information Architecture
+
+Every piece of data in Runaway should be designed for three consumption contexts:
+
+### Tier 1: Glance (Widget / Watch / Lock Screen)
+- **Single key metric** - the one number that matters most right now
+- Maximum 1-2 data points
+- Large, bold typography readable at arm's length
+- No interaction required to understand
+- Examples: Today's mileage, current streak, next workout
+
+### Tier 2: Quick View (App Home / Dashboard)
+- **3-5 primary stats** with trend indicators
+- Scannable in 2-3 seconds
+- Visual hierarchy guides eye to most important info first
+- Trend arrows/colors show direction without requiring thought
+- Examples: Weekly summary card, training load indicator, recent activity list
+
+### Tier 3: Deep Dive (Detail Screens / Analysis)
+- Full historical context and insights
+- Interactive charts and filters
+- Comparative analysis (vs last week, vs PR, vs plan)
+- Only shown when user explicitly requests depth
+- Examples: Activity detail view, performance analytics, training history
+
+---
+
+## Context-Aware Design
+
+### During Active Runs (Motion Context)
+- **Larger touch targets** (minimum 60pt, prefer 80pt+)
+- **Simplified UI** - remove all non-essential elements
+- **High contrast** for outdoor visibility
+- **Reduced cognitive load** - no decisions required
+- **Haptic feedback** for confirmations
+- Single-tap actions only (no swipes or long-press)
+
+### Post-Workout / Stationary Context
+- Standard touch targets (44pt minimum)
+- Full analytics and insights available
+- Comparative data and trends
+- Edit/annotation capabilities
+- Share and export options
+
+### Recovery / Rest Day Context
+- Emphasize recovery metrics
+- Suggest light activities
+- Show streak maintenance options
+- Celebrate rest as part of training
+
+---
+
+## Smart Metric Prioritization
+
+Surface the most relevant data based on training phase:
+
+| Training Phase | Primary Metrics | Secondary Metrics |
+|----------------|-----------------|-------------------|
+| **Base Building** | Weekly mileage, consistency streak | Easy pace compliance, heart rate zones |
+| **Race Prep** | Workout quality, race pace progress | Taper compliance, readiness score |
+| **Recovery** | Rest days taken, sleep quality | HRV trends, fatigue indicators |
+| **Maintenance** | Activity frequency, variety | Enjoyment metrics, social engagement |
+
+---
+
+## Progressive Disclosure in Data Visualization
+
+### Charts and Graphs
+1. **Default view:** Simplified trend (sparkline or single stat)
+2. **First tap:** Expanded view with labeled axes and key data points
+3. **Second tap/interaction:** Full breakdown with filters, comparisons, and details
+
+### Metric Cards
+1. **Collapsed:** Single value with trend indicator
+2. **Expanded:** Value + context (vs average, vs goal, vs last period)
+3. **Detail sheet:** Historical chart + insights + related metrics
+
+---
+
+## Visual Design Guidelines
+
+### Typography Hierarchy
+```
+Headline (Glance): SF Pro Display Bold, 34-48pt
+Primary Stat: SF Pro Display Semibold, 24-32pt
+Secondary Stat: SF Pro Text Medium, 17-20pt
+Supporting Text: SF Pro Text Regular, 13-15pt
+Caption/Label: SF Pro Text Regular, 11-13pt
+```
+
+### Spacing System
+- Base unit: 8pt
+- Compact context (active run): 4pt base
+- Standard context: 8pt base
+- Comfortable context (analysis): 12pt base
+
+### Color Usage
+- **Primary metrics:** High contrast (white on dark, black on light)
+- **Positive trends:** System green (`Color.green`)
+- **Negative trends:** System red (`Color.red`)
+- **Neutral/stable:** System gray
+- **Interactive elements:** App accent color
+
+### Touch Targets
+- **Minimum:** 44x44pt (Apple HIG standard)
+- **Preferred:** 48x48pt
+- **Active run context:** 60x60pt minimum, 80x80pt preferred
+
+---
+
+## Component Patterns
+
+### Metric Card (Reusable)
+Every metric display should use a consistent card pattern:
+- Value prominently displayed
+- Label below or beside value
+- Trend indicator (arrow + percentage or sparkline)
+- Tap to expand for context
+- Responds to size class changes
+
+### Responsive Layouts
+- Use `GeometryReader` for adaptive sizing
+- Implement size class awareness (`@Environment(\.horizontalSizeClass)`)
+- Create view modifiers for context-based density
+- Test on all device sizes (SE to Pro Max)
+
+### Animation Guidelines
+- Chart transitions: 0.3s ease-in-out
+- Card expand/collapse: 0.25s spring
+- Value changes: 0.2s with number counting effect
+- Use `withAnimation` blocks, not implicit animations
+
+---
+
+## Implementation Checklist
+
+When building any new UI component, verify:
+
+- [ ] Works at all three information tiers
+- [ ] Adapts to motion/stationary context
+- [ ] Follows typography hierarchy
+- [ ] Meets touch target requirements
+- [ ] Uses progressive disclosure for complex data
+- [ ] Tested on smallest (iPhone SE) and largest (Pro Max) devices
+- [ ] Supports Dynamic Type accessibility
+- [ ] Dark mode compatible
+- [ ] VoiceOver accessible with meaningful labels
+
+---
+
+## Anti-Patterns to Avoid
+
+1. **Information overload on home screen** - If you show everything, nothing stands out
+2. **Requiring precision taps during runs** - Users are moving and sweaty
+3. **Hiding critical data behind multiple taps** - Glanceable means visible immediately
+4. **Inconsistent metric cards** - Every stat should look/behave the same way
+5. **Static layouts** - Everything should adapt to context and device
+6. **Decorative animations** - Every animation should convey meaning or aid comprehension
+7. **Text-heavy explanations** - Use visual hierarchy and icons instead
+
+---
+
+## Resources
+
+- [Apple Human Interface Guidelines - Charts](https://developer.apple.com/design/human-interface-guidelines/charts)
+- [Apple Charts Framework Documentation](https://developer.apple.com/documentation/charts)
+- [Material Design - Data Visualization](https://m3.material.io/styles/data-visualization)
+- [Fitbit Design Language](https://design.fitbit.com/) (competitor reference)
+
+---
+
+*Last updated: January 2026*
+*These principles should evolve as we learn from user feedback and usage patterns.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Critical Design Documents
+
+**IMPORTANT:** Before making ANY UI/UX changes, review these documents:
+
+- **[UX Design Principles](/.claude/UX-DESIGN-PRINCIPLES.md)** - Core design philosophy, three-tier information architecture, context-aware design patterns, and component guidelines. All UI work MUST follow these principles.
+
 ## Build Commands
 
 ### Development Build

--- a/Runaway iOS.xcodeproj/project.pbxproj
+++ b/Runaway iOS.xcodeproj/project.pbxproj
@@ -599,10 +599,10 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Runaway uses your health data to calculate your daily readiness score, track recovery, and provide personalized training recommendations based on your sleep, heart rate variability, and resting heart rate.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Runaway saves your workouts to Apple Health so they appear in the Fitness app and contribute to your Activity rings.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Runaway uses speech recognition to enable hands-free voice commands during your runs, allowing you to interact with your audio coach without looking at your phone.";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Runaway needs background location access to continue tracking your run when your phone is locked or in your pocket.";
 				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "Runaway iOS needs Location access for \"some reason\"!";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Runaway needs your location to track your runs and display your route on the map.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Runaway uses speech recognition to enable hands-free voice commands during your runs, allowing you to interact with your audio coach without looking at your phone.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -643,10 +643,10 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Runaway uses your health data to calculate your daily readiness score, track recovery, and provide personalized training recommendations based on your sleep, heart rate variability, and resting heart rate.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Runaway saves your workouts to Apple Health so they appear in the Fitness app and contribute to your Activity rings.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Runaway uses speech recognition to enable hands-free voice commands during your runs, allowing you to interact with your audio coach without looking at your phone.";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Runaway needs background location access to continue tracking your run when your phone is locked or in your pocket.";
 				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "Runaway iOS needs Location access for \"some reason\"!";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Runaway needs your location to track your runs and display your route on the map.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Runaway uses speech recognition to enable hands-free voice commands during your runs, allowing you to interact with your audio coach without looking at your phone.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;

--- a/Runaway iOS/Components/CompactCommitmentCard.swift
+++ b/Runaway iOS/Components/CompactCommitmentCard.swift
@@ -1,0 +1,217 @@
+//
+//  CompactCommitmentCard.swift
+//  Runaway iOS
+//
+//  Condensed commitment card for Activities tab - single row layout
+//
+
+import SwiftUI
+
+struct CompactCommitmentCard: View {
+    @EnvironmentObject var dataManager: DataManager
+    @State private var showingFullCommitment = false
+
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    private var backgroundColor: Color {
+        themeManager.isDarkMode
+            ? AppTheme.Colors.DarkMode.cardBackground
+            : AppTheme.Colors.LightMode.cardBackground
+    }
+
+    private var textPrimary: Color {
+        themeManager.isDarkMode
+            ? AppTheme.Colors.DarkMode.textPrimary
+            : AppTheme.Colors.LightMode.textPrimary
+    }
+
+    private var textSecondary: Color {
+        themeManager.isDarkMode
+            ? AppTheme.Colors.DarkMode.textSecondary
+            : AppTheme.Colors.LightMode.textSecondary
+    }
+
+    var body: some View {
+        Button(action: { showingFullCommitment = true }) {
+            HStack(spacing: AppTheme.Spacing.md) {
+                // Status icon
+                statusIcon
+
+                // Content
+                VStack(alignment: .leading, spacing: 2) {
+                    if let commitment = dataManager.todaysCommitment {
+                        if commitment.isFulfilled {
+                            fulfilledContent(commitment)
+                        } else {
+                            activeContent(commitment)
+                        }
+                    } else {
+                        noCommitmentContent
+                    }
+                }
+
+                Spacer()
+
+                // Action indicator
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(textSecondary)
+            }
+            .padding(AppTheme.Spacing.md)
+            .background(backgroundColor)
+            .cornerRadius(AppTheme.CornerRadius.medium)
+            .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .sheet(isPresented: $showingFullCommitment) {
+            NavigationView {
+                FullCommitmentSheet()
+                    .environmentObject(dataManager)
+            }
+        }
+    }
+
+    // MARK: - Status Icon
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        if let commitment = dataManager.todaysCommitment {
+            if commitment.isFulfilled {
+                // Completed - green checkmark
+                ZStack {
+                    Circle()
+                        .fill(AppTheme.Colors.success.opacity(0.15))
+                        .frame(width: 40, height: 40)
+
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(AppTheme.Colors.success)
+                }
+            } else {
+                // Active - activity icon with accent
+                ZStack {
+                    Circle()
+                        .fill(AppTheme.Colors.accent.opacity(0.15))
+                        .frame(width: 40, height: 40)
+
+                    Image(systemName: commitment.activityType.icon)
+                        .font(.system(size: 18))
+                        .foregroundColor(AppTheme.Colors.accent)
+                }
+            }
+        } else {
+            // No commitment - plus icon
+            ZStack {
+                Circle()
+                    .stroke(textSecondary.opacity(0.3), lineWidth: 1.5)
+                    .frame(width: 40, height: 40)
+
+                Image(systemName: "plus")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(textSecondary)
+            }
+        }
+    }
+
+    // MARK: - Content Views
+
+    @ViewBuilder
+    private func fulfilledContent(_ commitment: DailyCommitment) -> some View {
+        Text("Commitment Complete!")
+            .font(AppTheme.Typography.body)
+            .fontWeight(.semibold)
+            .foregroundColor(AppTheme.Colors.success)
+
+        Text("\(commitment.activityType.displayName) done today")
+            .font(AppTheme.Typography.caption)
+            .foregroundColor(textSecondary)
+    }
+
+    @ViewBuilder
+    private func activeContent(_ commitment: DailyCommitment) -> some View {
+        HStack(spacing: AppTheme.Spacing.xs) {
+            Text("Today:")
+                .font(AppTheme.Typography.body)
+                .foregroundColor(textSecondary)
+
+            Text(commitment.activityType.displayName)
+                .font(AppTheme.Typography.body)
+                .fontWeight(.semibold)
+                .foregroundColor(textPrimary)
+        }
+
+        if commitment.timeRemainingToday > 0 {
+            Text(commitment.timeRemainingText)
+                .font(AppTheme.Typography.caption)
+                .foregroundColor(AppTheme.Colors.accent)
+        } else {
+            Text("Commitment expired")
+                .font(AppTheme.Typography.caption)
+                .foregroundColor(AppTheme.Colors.error)
+        }
+    }
+
+    @ViewBuilder
+    private var noCommitmentContent: some View {
+        Text("Set today's commitment")
+            .font(AppTheme.Typography.body)
+            .fontWeight(.medium)
+            .foregroundColor(textPrimary)
+
+        Text("Tap to commit to an activity")
+            .font(AppTheme.Typography.caption)
+            .foregroundColor(textSecondary)
+    }
+}
+
+// MARK: - Full Commitment Sheet
+
+struct FullCommitmentSheet: View {
+    @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var dataManager: DataManager
+
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    private var backgroundColor: Color {
+        themeManager.isDarkMode
+            ? AppTheme.Colors.DarkMode.background
+            : AppTheme.Colors.LightMode.background
+    }
+
+    var body: some View {
+        ZStack {
+            backgroundColor.ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: AppTheme.Spacing.lg) {
+                    // Embed the full ActivityCommitmentCard
+                    ActivityCommitmentCard()
+                        .environmentObject(dataManager)
+                }
+                .padding(AppTheme.Spacing.md)
+            }
+        }
+        .navigationTitle("Today's Commitment")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Done") { dismiss() }
+                    .foregroundColor(AppTheme.Colors.accent)
+            }
+        }
+    }
+}
+
+#Preview("With Active Commitment") {
+    CompactCommitmentCard()
+        .padding()
+        .background(Color.gray.opacity(0.1))
+        .environmentObject(DataManager.shared)
+}
+
+#Preview("No Commitment") {
+    CompactCommitmentCard()
+        .padding()
+        .background(Color.gray.opacity(0.1))
+        .environmentObject(DataManager.shared)
+}

--- a/Runaway iOS/Components/CustomTabBar.swift
+++ b/Runaway iOS/Components/CustomTabBar.swift
@@ -60,6 +60,7 @@ struct CustomTabBar: View {
                         .foregroundColor(borderColor),
                     alignment: .top
                 )
+                .ignoresSafeArea(edges: .bottom)
         )
     }
 

--- a/Runaway iOS/Components/CustomTabBar.swift
+++ b/Runaway iOS/Components/CustomTabBar.swift
@@ -1,0 +1,89 @@
+//
+//  CustomTabBar.swift
+//  Runaway iOS
+//
+//  Custom tab bar with prominent center Record button
+//
+
+import SwiftUI
+
+struct CustomTabBar: View {
+    @Binding var selectedTab: Int
+    @Binding var showRecording: Bool
+
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    private var backgroundColor: Color {
+        themeManager.isDarkMode
+            ? AppTheme.Colors.DarkMode.cardBackground
+            : AppTheme.Colors.LightMode.cardBackground
+    }
+
+    private var borderColor: Color {
+        themeManager.isDarkMode
+            ? Color.white.opacity(0.1)
+            : Color.black.opacity(0.08)
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Tab 0: Activities
+            TabBarButton(icon: "figure.run", label: "Activities", isSelected: selectedTab == 0)
+                .onTapGesture { selectedTab = 0 }
+
+            // Tab 1: Progress
+            TabBarButton(icon: "chart.bar.fill", label: "Progress", isSelected: selectedTab == 1)
+                .onTapGesture { selectedTab = 1 }
+
+            // Center: Record button (larger, prominent)
+            recordButton
+                .frame(maxWidth: .infinity)
+
+            // Tab 3: Plan
+            TabBarButton(icon: "calendar.badge.clock", label: "Plan", isSelected: selectedTab == 3)
+                .onTapGesture { selectedTab = 3 }
+
+            // Tab 4: Profile
+            TabBarButton(icon: "person.fill", label: "Profile", isSelected: selectedTab == 4)
+                .onTapGesture { selectedTab = 4 }
+        }
+        .padding(.horizontal, AppTheme.Spacing.md)
+        .padding(.top, AppTheme.Spacing.sm)
+        .padding(.bottom, 28) // Account for home indicator
+        .background(
+            Rectangle()
+                .fill(backgroundColor)
+                .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: -4)
+                .overlay(
+                    Rectangle()
+                        .frame(height: 0.5)
+                        .foregroundColor(borderColor),
+                    alignment: .top
+                )
+        )
+    }
+
+    private var recordButton: some View {
+        Button(action: { showRecording = true }) {
+            ZStack {
+                Circle()
+                    .fill(AppTheme.Colors.accentGradient)
+                    .frame(width: 56, height: 56)
+                    .shadow(color: AppTheme.Colors.accent.opacity(0.4), radius: 8, x: 0, y: 4)
+
+                Image(systemName: "plus")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundColor(.black)
+            }
+        }
+        .offset(y: -12) // Lift above tab bar
+    }
+}
+
+#Preview {
+    VStack {
+        Spacer()
+        CustomTabBar(selectedTab: .constant(0), showRecording: .constant(false))
+    }
+    .background(Color.gray.opacity(0.2))
+}

--- a/Runaway iOS/Components/MetricCard.swift
+++ b/Runaway iOS/Components/MetricCard.swift
@@ -1,0 +1,362 @@
+//
+//  MetricCard.swift
+//  Runaway iOS
+//
+//  Reusable metric display component following UX Design Principles.
+//  Implements Tier 2 Quick View pattern with consistent styling.
+//
+
+import SwiftUI
+
+// MARK: - Metric Card Style
+
+/// Defines the visual style of the metric card
+enum MetricCardStyle {
+    /// Large value with unit, icon + label, card background (32pt value)
+    case primary
+    /// Medium value with label, subtle card background (headline value)
+    case secondary
+    /// Compact inline display without background (for use in rows)
+    case inline
+    /// Inline with primary sizing (larger text, no background)
+    case inlinePrimary
+}
+
+// MARK: - Metric Card
+
+/// Reusable component for displaying metrics consistently across the app.
+/// Follows the three-tier information architecture from UX-DESIGN-PRINCIPLES.md
+struct MetricCard: View {
+    let value: String
+    var unit: String? = nil
+    let label: String
+    var icon: String? = nil
+    var style: MetricCardStyle = .primary
+    var trend: Double? = nil
+
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    // MARK: - Theme Colors
+
+    private var textPrimary: Color {
+        themeManager.isDarkMode ? AppTheme.Colors.DarkMode.textPrimary : AppTheme.Colors.LightMode.textPrimary
+    }
+
+    private var textSecondary: Color {
+        themeManager.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary
+    }
+
+    private var textTertiary: Color {
+        themeManager.isDarkMode ? AppTheme.Colors.DarkMode.textTertiary : AppTheme.Colors.LightMode.textTertiary
+    }
+
+    private var cardBackground: Color {
+        switch style {
+        case .primary:
+            return themeManager.isDarkMode ? Color.white.opacity(0.08) : Color.black.opacity(0.04)
+        case .secondary:
+            return themeManager.isDarkMode ? Color.white.opacity(0.05) : Color.black.opacity(0.03)
+        case .inline, .inlinePrimary:
+            return .clear
+        }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, verticalPadding)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(cardBackground)
+            )
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        VStack(spacing: contentSpacing) {
+            // Value + Unit row
+            HStack(alignment: .lastTextBaseline, spacing: unitSpacing) {
+                Text(value)
+                    .font(valueFont)
+                    .fontWeight(.bold)
+                    .foregroundColor(textPrimary)
+                    .monospacedDigit()
+
+                if let unit = unit {
+                    Text(unit)
+                        .font(unitFont)
+                        .fontWeight(.medium)
+                        .foregroundColor(textSecondary)
+                }
+
+                // Trend indicator (if provided)
+                if let trend = trend {
+                    trendBadge(trend: trend)
+                }
+            }
+
+            // Label + Icon row
+            HStack(spacing: 4) {
+                if let icon = icon {
+                    Image(systemName: icon)
+                        .font(iconFont)
+                }
+                Text(label)
+                    .font(labelFont)
+            }
+            .foregroundColor(labelColor)
+        }
+    }
+
+    // MARK: - Trend Badge
+
+    @ViewBuilder
+    private func trendBadge(trend: Double) -> some View {
+        let isPositive = trend >= 0
+        let trendColor = isPositive ? AppTheme.Colors.success : AppTheme.Colors.error
+        let arrow = isPositive ? "arrow.up.right" : "arrow.down.right"
+        let percentage = abs(trend * 100)
+
+        HStack(spacing: 2) {
+            Image(systemName: arrow)
+                .font(.system(size: 8, weight: .bold))
+            Text(String(format: "%.0f%%", percentage))
+                .font(.system(size: 10, weight: .semibold))
+        }
+        .foregroundColor(trendColor)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(trendColor.opacity(0.15))
+        .cornerRadius(4)
+    }
+
+    // MARK: - Style-based Properties
+
+    private var valueFont: Font {
+        switch style {
+        case .primary:
+            return .system(size: 32, weight: .bold, design: .rounded)
+        case .secondary:
+            return .headline
+        case .inline:
+            return AppTheme.Typography.title2
+        case .inlinePrimary:
+            return AppTheme.Typography.title
+        }
+    }
+
+    private var unitFont: Font {
+        switch style {
+        case .primary:
+            return .subheadline
+        case .secondary:
+            return .caption
+        case .inline, .inlinePrimary:
+            return AppTheme.Typography.caption
+        }
+    }
+
+    private var labelFont: Font {
+        switch style {
+        case .primary:
+            return .caption
+        case .secondary:
+            return .caption2
+        case .inline, .inlinePrimary:
+            return AppTheme.Typography.caption
+        }
+    }
+
+    private var iconFont: Font {
+        switch style {
+        case .primary:
+            return .caption
+        case .secondary:
+            return .caption2
+        case .inline, .inlinePrimary:
+            return .system(size: 10)
+        }
+    }
+
+    private var labelColor: Color {
+        switch style {
+        case .primary, .secondary:
+            return textSecondary
+        case .inline, .inlinePrimary:
+            return textTertiary
+        }
+    }
+
+    private var contentSpacing: CGFloat {
+        switch style {
+        case .primary:
+            return 8
+        case .secondary:
+            return 4
+        case .inline, .inlinePrimary:
+            return 4
+        }
+    }
+
+    private var unitSpacing: CGFloat {
+        switch style {
+        case .primary:
+            return 4
+        case .secondary, .inline, .inlinePrimary:
+            return 2
+        }
+    }
+
+    private var verticalPadding: CGFloat {
+        switch style {
+        case .primary:
+            return 16
+        case .secondary:
+            return 12
+        case .inline, .inlinePrimary:
+            return 0
+        }
+    }
+
+    private var cornerRadius: CGFloat {
+        switch style {
+        case .primary:
+            return 16
+        case .secondary:
+            return 12
+        case .inline, .inlinePrimary:
+            return 0
+        }
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension MetricCard {
+    /// Creates a primary metric card with all options
+    static func primary(
+        value: String,
+        unit: String,
+        label: String,
+        icon: String,
+        trend: Double? = nil
+    ) -> MetricCard {
+        MetricCard(
+            value: value,
+            unit: unit,
+            label: label,
+            icon: icon,
+            style: .primary,
+            trend: trend
+        )
+    }
+
+    /// Creates a secondary metric card (compact)
+    static func secondary(
+        value: String,
+        label: String
+    ) -> MetricCard {
+        MetricCard(
+            value: value,
+            label: label,
+            style: .secondary
+        )
+    }
+
+    /// Creates an inline metric (no background)
+    static func inline(
+        value: String,
+        unit: String? = nil,
+        label: String,
+        icon: String,
+        isPrimary: Bool = false
+    ) -> MetricCard {
+        MetricCard(
+            value: value,
+            unit: unit,
+            label: label,
+            icon: icon,
+            style: isPrimary ? .inlinePrimary : .inline
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Primary Style") {
+    VStack(spacing: 16) {
+        HStack(spacing: 16) {
+            MetricCard.primary(
+                value: "5.23",
+                unit: "mi",
+                label: "Distance",
+                icon: "point.topleft.down.to.point.bottomright.curvepath"
+            )
+
+            MetricCard.primary(
+                value: "8:42",
+                unit: "/mi",
+                label: "Pace",
+                icon: "speedometer"
+            )
+        }
+    }
+    .padding()
+    .background(Color.gray.opacity(0.1))
+}
+
+#Preview("Secondary Style") {
+    HStack(spacing: 12) {
+        MetricCard.secondary(value: "8:30", label: "Avg Pace")
+        MetricCard.secondary(value: "7.5", label: "Speed (mph)")
+    }
+    .padding()
+    .background(Color.gray.opacity(0.1))
+}
+
+#Preview("Inline Style") {
+    HStack(spacing: 16) {
+        MetricCard.inline(
+            value: "12.5",
+            unit: "mi",
+            label: "Distance",
+            icon: "road.lanes",
+            isPrimary: true
+        )
+
+        Divider().frame(height: 40)
+
+        MetricCard.inline(
+            value: "3",
+            label: "Activities",
+            icon: "figure.run"
+        )
+
+        Divider().frame(height: 40)
+
+        MetricCard.inline(
+            value: "1h 45m",
+            label: "Time",
+            icon: "clock"
+        )
+    }
+    .padding()
+    .background(Color.gray.opacity(0.1))
+}
+
+#Preview("With Trend") {
+    MetricCard(
+        value: "15.2",
+        unit: "mi",
+        label: "This Week",
+        icon: "road.lanes",
+        style: .primary,
+        trend: 0.23
+    )
+    .padding()
+    .background(Color.gray.opacity(0.1))
+}

--- a/Runaway iOS/Components/TabBarButton.swift
+++ b/Runaway iOS/Components/TabBarButton.swift
@@ -1,0 +1,51 @@
+//
+//  TabBarButton.swift
+//  Runaway iOS
+//
+//  Reusable tab bar button component for custom tab bar
+//
+
+import SwiftUI
+
+struct TabBarButton: View {
+    let icon: String
+    let label: String
+    let isSelected: Bool
+
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    private var foregroundColor: Color {
+        if isSelected {
+            return AppTheme.Colors.accent
+        } else {
+            return themeManager.isDarkMode
+                ? AppTheme.Colors.DarkMode.textTertiary
+                : AppTheme.Colors.LightMode.textTertiary
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 22))
+                .fontWeight(isSelected ? .semibold : .regular)
+
+            Text(label)
+                .font(.system(size: 10, weight: isSelected ? .semibold : .regular))
+        }
+        .foregroundColor(foregroundColor)
+        .frame(maxWidth: .infinity)
+        .contentShape(Rectangle())
+    }
+}
+
+#Preview {
+    HStack {
+        TabBarButton(icon: "figure.run", label: "Activities", isSelected: true)
+        TabBarButton(icon: "chart.bar.fill", label: "Progress", isSelected: false)
+        TabBarButton(icon: "calendar.badge.clock", label: "Plan", isSelected: false)
+        TabBarButton(icon: "person.fill", label: "Profile", isSelected: false)
+    }
+    .padding()
+    .background(Color.black)
+}

--- a/Runaway iOS/Components/WeeklyStatsCard.swift
+++ b/Runaway iOS/Components/WeeklyStatsCard.swift
@@ -1,0 +1,360 @@
+//
+//  WeeklyStatsCard.swift
+//  Runaway iOS
+//
+//  Tier 2 dashboard component showing weekly summary statistics
+//  Implements glanceable data hierarchy per UX-DESIGN-PRINCIPLES.md
+//
+
+import SwiftUI
+
+// MARK: - Weekly Stats Card
+
+/// Tier 2 Quick View component for the dashboard
+/// Shows 3-5 primary stats with trend indicators, scannable in 2-3 seconds
+struct WeeklyStatsCard: View {
+    @EnvironmentObject var dataManager: DataManager
+    @ObservedObject private var goalStore = GoalSettingsStore.shared
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    // MARK: - Computed Stats
+
+    private var weeklyStats: WeeklyActivityStats {
+        WeeklyActivityStats(activities: dataManager.activities)
+    }
+
+    private var weeklyGoal: Double {
+        goalStore.settings.weeklyGoalMiles
+    }
+
+    private var goalProgress: Double {
+        guard weeklyGoal > 0 else { return 0 }
+        return min(weeklyStats.totalMiles / weeklyGoal, 1.0)
+    }
+
+    // MARK: - Theme Colors
+
+    private var cardBackground: Color {
+        themeManager.isDarkMode ? AppTheme.Colors.DarkMode.cardBackground : AppTheme.Colors.LightMode.cardBackground
+    }
+
+    private var textPrimary: Color {
+        themeManager.isDarkMode ? AppTheme.Colors.DarkMode.textPrimary : AppTheme.Colors.LightMode.textPrimary
+    }
+
+    private var textSecondary: Color {
+        themeManager.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary
+    }
+
+    private var textTertiary: Color {
+        themeManager.isDarkMode ? AppTheme.Colors.DarkMode.textTertiary : AppTheme.Colors.LightMode.textTertiary
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
+            // Header
+            headerSection
+
+            // Main stats row
+            mainStatsRow
+
+            // Goal progress bar
+            goalProgressSection
+        }
+        .padding(AppTheme.Spacing.lg)
+        .background(cardBackground)
+        .cornerRadius(AppTheme.CornerRadius.large)
+        .shadow(
+            color: themeManager.isDarkMode ? Color.black.opacity(0.3) : Color.black.opacity(0.08),
+            radius: 8,
+            x: 0,
+            y: 4
+        )
+    }
+
+    // MARK: - Header Section
+
+    private var headerSection: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("This Week")
+                    .font(AppTheme.Typography.headline)
+                    .foregroundColor(textPrimary)
+
+                Text(weekDateRange)
+                    .font(AppTheme.Typography.caption)
+                    .foregroundColor(textTertiary)
+            }
+
+            Spacer()
+
+            // Week-over-week trend
+            if let trend = weeklyStats.weekOverWeekTrend {
+                trendBadge(trend: trend)
+            }
+        }
+    }
+
+    private var weekDateRange: String {
+        let calendar = Calendar.current
+        let today = Date()
+        guard let weekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: today)) else {
+            return ""
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        let startStr = formatter.string(from: weekStart)
+        let endStr = formatter.string(from: today)
+        return "\(startStr) - \(endStr)"
+    }
+
+    @ViewBuilder
+    private func trendBadge(trend: Double) -> some View {
+        let isPositive = trend >= 0
+        let trendColor = isPositive ? AppTheme.Colors.success : AppTheme.Colors.error
+        let arrow = isPositive ? "arrow.up.right" : "arrow.down.right"
+        let percentage = abs(trend * 100)
+
+        HStack(spacing: 4) {
+            Image(systemName: arrow)
+                .font(.system(size: 10, weight: .bold))
+            Text(String(format: "%.0f%%", percentage))
+                .font(AppTheme.Typography.caption)
+                .fontWeight(.semibold)
+        }
+        .foregroundColor(trendColor)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(trendColor.opacity(0.15))
+        .cornerRadius(AppTheme.CornerRadius.small)
+    }
+
+    // MARK: - Main Stats Row
+
+    private var mainStatsRow: some View {
+        HStack(spacing: AppTheme.Spacing.md) {
+            // Primary: Distance
+            statItem(
+                value: UnitFormatter.formatDistance(weeklyStats.totalMeters, decimals: 1, includeUnit: false),
+                unit: UnitFormatter.distanceUnitAbbreviation,
+                label: "Distance",
+                icon: "road.lanes",
+                isPrimary: true
+            )
+
+            Divider()
+                .frame(height: 40)
+
+            // Activities count
+            statItem(
+                value: "\(weeklyStats.activityCount)",
+                unit: nil,
+                label: "Activities",
+                icon: "figure.run",
+                isPrimary: false
+            )
+
+            Divider()
+                .frame(height: 40)
+
+            // Time
+            statItem(
+                value: formatDuration(weeklyStats.totalSeconds),
+                unit: nil,
+                label: "Time",
+                icon: "clock",
+                isPrimary: false
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func statItem(value: String, unit: String?, label: String, icon: String, isPrimary: Bool) -> some View {
+        VStack(spacing: 4) {
+            HStack(alignment: .lastTextBaseline, spacing: 2) {
+                Text(value)
+                    .font(isPrimary ? AppTheme.Typography.title : AppTheme.Typography.title2)
+                    .fontWeight(.bold)
+                    .foregroundColor(textPrimary)
+                    .monospacedDigit()
+
+                if let unit = unit {
+                    Text(unit)
+                        .font(AppTheme.Typography.caption)
+                        .foregroundColor(textSecondary)
+                }
+            }
+
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 10))
+                Text(label)
+                    .font(AppTheme.Typography.caption)
+            }
+            .foregroundColor(textTertiary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func formatDuration(_ seconds: Int) -> String {
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        } else {
+            return "\(minutes)m"
+        }
+    }
+
+    // MARK: - Goal Progress Section
+
+    private var goalProgressSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Weekly Goal")
+                    .font(AppTheme.Typography.caption)
+                    .foregroundColor(textSecondary)
+
+                Spacer()
+
+                Text("\(UnitFormatter.formatDistance(weeklyStats.totalMeters, decimals: 1, includeUnit: false)) / \(Int(UnitFormatter.metersToPreferredUnit(weeklyGoal * 1609.34))) \(UnitFormatter.distanceUnitAbbreviation)")
+                    .font(AppTheme.Typography.caption)
+                    .fontWeight(.medium)
+                    .foregroundColor(textPrimary)
+            }
+
+            // Progress bar
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    // Track
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(AppTheme.Colors.Semantic.progressTrack)
+                        .frame(height: 8)
+
+                    // Fill
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(progressColor)
+                        .frame(width: geometry.size.width * goalProgress, height: 8)
+                }
+            }
+            .frame(height: 8)
+
+            // Progress percentage or completion message
+            HStack {
+                if goalProgress >= 1.0 {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(AppTheme.Colors.success)
+                    Text("Goal achieved!")
+                        .font(AppTheme.Typography.caption)
+                        .foregroundColor(AppTheme.Colors.success)
+                } else {
+                    let remaining = weeklyGoal - weeklyStats.totalMiles
+                    Text("\(UnitFormatter.formatDistance(remaining * 1609.34, decimals: 1, includeUnit: true)) to go")
+                        .font(AppTheme.Typography.caption)
+                        .foregroundColor(textTertiary)
+                }
+
+                Spacer()
+
+                Text("\(Int(goalProgress * 100))%")
+                    .font(AppTheme.Typography.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(textSecondary)
+            }
+        }
+    }
+
+    private var progressColor: Color {
+        if goalProgress >= 1.0 {
+            return AppTheme.Colors.success
+        } else if goalProgress >= 0.75 {
+            return AppTheme.Colors.accent
+        } else if goalProgress >= 0.5 {
+            return AppTheme.Colors.warning
+        } else {
+            return AppTheme.Colors.accent.opacity(0.7)
+        }
+    }
+}
+
+// MARK: - Weekly Activity Stats Calculator
+
+struct WeeklyActivityStats {
+    let totalMeters: Double
+    let totalMiles: Double
+    let activityCount: Int
+    let totalSeconds: Int
+    let weekOverWeekTrend: Double?
+
+    init(activities: [Activity]) {
+        let calendar = Calendar.current
+        let today = Date()
+
+        // Get start of current week (Sunday)
+        guard let currentWeekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: today)) else {
+            self.totalMeters = 0
+            self.totalMiles = 0
+            self.activityCount = 0
+            self.totalSeconds = 0
+            self.weekOverWeekTrend = nil
+            return
+        }
+
+        // Get start of previous week
+        guard let previousWeekStart = calendar.date(byAdding: .weekOfYear, value: -1, to: currentWeekStart) else {
+            self.totalMeters = 0
+            self.totalMiles = 0
+            self.activityCount = 0
+            self.totalSeconds = 0
+            self.weekOverWeekTrend = nil
+            return
+        }
+
+        // Filter current week activities
+        let currentWeekActivities = activities.filter { activity in
+            guard let activityDate = activity.activity_date ?? activity.start_date else { return false }
+            let date = Date(timeIntervalSince1970: activityDate)
+            return date >= currentWeekStart && date <= today
+        }
+
+        // Filter previous week activities
+        let previousWeekActivities = activities.filter { activity in
+            guard let activityDate = activity.activity_date ?? activity.start_date else { return false }
+            let date = Date(timeIntervalSince1970: activityDate)
+            return date >= previousWeekStart && date < currentWeekStart
+        }
+
+        // Calculate current week stats
+        let currentDistance = currentWeekActivities.reduce(0.0) { $0 + ($1.distance ?? 0) }
+        let currentTime = currentWeekActivities.reduce(0) { $0 + Int($1.elapsed_time ?? 0) }
+
+        self.totalMeters = currentDistance
+        self.totalMiles = currentDistance / 1609.34
+        self.activityCount = currentWeekActivities.count
+        self.totalSeconds = currentTime
+
+        // Calculate week-over-week trend
+        let previousDistance = previousWeekActivities.reduce(0.0) { $0 + ($1.distance ?? 0) }
+        if previousDistance > 0 {
+            self.weekOverWeekTrend = (currentDistance - previousDistance) / previousDistance
+        } else if currentDistance > 0 {
+            self.weekOverWeekTrend = 1.0 // 100% increase if previous was 0
+        } else {
+            self.weekOverWeekTrend = nil
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack {
+        WeeklyStatsCard()
+            .padding()
+    }
+    .background(Color.gray.opacity(0.1))
+    .environmentObject(DataManager.shared)
+}

--- a/Runaway iOS/Database/Migrations/006_add_lifetime_stats_function.sql
+++ b/Runaway iOS/Database/Migrations/006_add_lifetime_stats_function.sql
@@ -23,7 +23,7 @@ BEGIN
         'weekly_streak', (
             WITH weeks_with_runs AS (
                 SELECT DISTINCT
-                    DATE_TRUNC('week', TO_TIMESTAMP(activity_date))::DATE as week_start
+                    DATE_TRUNC('week', activity_date)::DATE as week_start
                 FROM activities
                 WHERE athlete_id = p_athlete_id
                 AND activity_type_id IN (SELECT id FROM activity_types WHERE LOWER(name) LIKE '%run%')

--- a/Runaway iOS/Utils/Theme.swift
+++ b/Runaway iOS/Utils/Theme.swift
@@ -467,6 +467,16 @@ struct AppTheme {
         // Pill & Badge Dimensions
         static let pillHeight: CGFloat = 32
         static let badgeSize: CGFloat = 20
+
+        // MARK: - Touch Targets (per UX-DESIGN-PRINCIPLES.md)
+        // Apple HIG minimum
+        static let touchTargetMinimum: CGFloat = 44
+        // Preferred for comfortable tapping
+        static let touchTargetPreferred: CGFloat = 48
+        // Motion context (during active runs) - minimum
+        static let touchTargetMotionMinimum: CGFloat = 60
+        // Motion context (during active runs) - preferred
+        static let touchTargetMotionPreferred: CGFloat = 80
     }
 }
 

--- a/Runaway iOS/Views/ActiveRecordingView.swift
+++ b/Runaway iOS/Views/ActiveRecordingView.swift
@@ -22,8 +22,15 @@ struct ActiveRecordingView: View {
     @State private var showingStopConfirmation = false
     @State private var showingPostRecording = false
     @State private var pulseAnimation = false
+    @State private var expandedMetric: ExpandedMetric? = nil
 
     @StateObject private var timerManager = TimerUpdateManager()
+
+    // Enum to track which metric card is expanded
+    private enum ExpandedMetric {
+        case distance
+        case pace
+    }
 
     // TODO: Re-enable when background audio mode is added back
     // @StateObject private var audioCoaching = AudioCoachingService()
@@ -67,6 +74,10 @@ struct ActiveRecordingView: View {
         themeManager.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary
     }
 
+    private var textTertiary: Color {
+        themeManager.isDarkMode ? AppTheme.Colors.DarkMode.textTertiary : AppTheme.Colors.LightMode.textTertiary
+    }
+
     var body: some View {
         ZStack {
             background.ignoresSafeArea()
@@ -88,13 +99,13 @@ struct ActiveRecordingView: View {
                 // Auto-pause indicator
                 if recordingService.isAutopaused {
                     autoPauseIndicator
-                        .padding(.top, 16)
+                        .padding(.top, AppTheme.Spacing.lg)
                 }
 
                 // Control buttons
                 controlButtons
-                    .padding(.top, 24)
-                    .padding(.bottom, 40)
+                    .padding(.top, AppTheme.Spacing.xxl)
+                    .padding(.bottom, AppTheme.Spacing.huge)
             }
         }
         .navigationBarHidden(true)
@@ -142,7 +153,7 @@ struct ActiveRecordingView: View {
     private var topStatusBar: some View {
         HStack {
             // Activity type indicator
-            HStack(spacing: 8) {
+            HStack(spacing: AppTheme.Spacing.sm) {
                 Image(systemName: activityIcon)
                     .font(.body)
                 Text(activityType)
@@ -150,8 +161,8 @@ struct ActiveRecordingView: View {
                     .fontWeight(.medium)
             }
             .foregroundColor(activityColor)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
+            .padding(.horizontal, AppTheme.Spacing.lg)
+            .padding(.vertical, AppTheme.Spacing.md)
             .background(
                 Capsule()
                     .fill(activityColor.opacity(0.15))
@@ -160,7 +171,7 @@ struct ActiveRecordingView: View {
             Spacer()
 
             // Recording state indicator
-            HStack(spacing: 6) {
+            HStack(spacing: AppTheme.Spacing.xs) {
                 Circle()
                     .fill(recordingStateColor)
                     .frame(width: 8, height: 8)
@@ -170,15 +181,15 @@ struct ActiveRecordingView: View {
                     .fontWeight(.medium)
                     .foregroundColor(textSecondary)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            .padding(.horizontal, AppTheme.Spacing.md)
+            .padding(.vertical, AppTheme.Spacing.sm)
             .background(
                 Capsule()
                     .fill(themeManager.isDarkMode ? Color.white.opacity(0.1) : Color.black.opacity(0.05))
             )
         }
-        .padding(.horizontal, 20)
-        .padding(.top, 16)
+        .padding(.horizontal, AppTheme.Spacing.xl)
+        .padding(.top, AppTheme.Spacing.lg)
     }
 
     private var recordingStateColor: Color {
@@ -239,26 +250,76 @@ struct ActiveRecordingView: View {
     // MARK: - Metrics Grid
 
     private var metricsGrid: some View {
-        VStack(spacing: 16) {
-            // Primary metrics row (Distance and Pace)
-            HStack(spacing: 20) {
-                primaryMetricCard(
+        VStack(spacing: AppTheme.Spacing.lg) {
+            // Primary metrics row (Distance and Pace) - tappable for expanded context
+            HStack(spacing: AppTheme.Spacing.xl) {
+                expandablePrimaryMetricCard(
                     value: UnitFormatter.formatDistance(recordingService.gpsService.totalDistance, decimals: 2, includeUnit: false),
                     unit: UnitFormatter.distanceUnitAbbreviation,
                     label: "Distance",
-                    icon: "point.topleft.down.to.point.bottomright.curvepath"
+                    icon: "point.topleft.down.to.point.bottomright.curvepath",
+                    metric: .distance,
+                    expandedContent: {
+                        // Show elapsed time context when expanded
+                        HStack(spacing: AppTheme.Spacing.md) {
+                            VStack(spacing: 2) {
+                                Text(formatTime(timerManager.elapsedTime))
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(textPrimary)
+                                Text("Elapsed")
+                                    .font(.caption2)
+                                    .foregroundColor(textTertiary)
+                            }
+                            Divider().frame(height: 24)
+                            VStack(spacing: 2) {
+                                Text("\(recordingService.gpsService.routePoints.count)")
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(textPrimary)
+                                Text("GPS pts")
+                                    .font(.caption2)
+                                    .foregroundColor(textTertiary)
+                            }
+                        }
+                    }
                 )
 
-                primaryMetricCard(
+                expandablePrimaryMetricCard(
                     value: UnitFormatter.formatPaceTime(minutesPerMile: recordingService.gpsService.currentPace),
                     unit: UnitFormatter.paceUnitLabel,
                     label: "Pace",
-                    icon: "speedometer"
+                    icon: "speedometer",
+                    metric: .pace,
+                    expandedContent: {
+                        // Show average pace comparison when expanded
+                        HStack(spacing: AppTheme.Spacing.md) {
+                            VStack(spacing: 2) {
+                                Text(UnitFormatter.formatPaceTime(minutesPerMile: recordingService.gpsService.averagePace))
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(textPrimary)
+                                Text("Average")
+                                    .font(.caption2)
+                                    .foregroundColor(textTertiary)
+                            }
+                            Divider().frame(height: 24)
+                            VStack(spacing: 2) {
+                                Text(UnitFormatter.formatSpeedValue(recordingService.gpsService.currentSpeed))
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(textPrimary)
+                                Text(UnitFormatter.speedUnitLabel)
+                                    .font(.caption2)
+                                    .foregroundColor(textTertiary)
+                            }
+                        }
+                    }
                 )
             }
 
             // Secondary metrics row (max 2 for glanceability)
-            HStack(spacing: 12) {
+            HStack(spacing: AppTheme.Spacing.md) {
                 secondaryMetricCard(
                     value: UnitFormatter.formatPaceTime(minutesPerMile: recordingService.gpsService.averagePace),
                     label: "Avg Pace"
@@ -270,12 +331,12 @@ struct ActiveRecordingView: View {
                 )
             }
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, AppTheme.Spacing.xl)
     }
 
     private func primaryMetricCard(value: String, unit: String, label: String, icon: String) -> some View {
-        VStack(spacing: 8) {
-            HStack(alignment: .lastTextBaseline, spacing: 4) {
+        VStack(spacing: AppTheme.Spacing.sm) {
+            HStack(alignment: .lastTextBaseline, spacing: AppTheme.Spacing.xs) {
                 Text(value)
                     .font(.system(size: 32, weight: .bold, design: .rounded))
                     .foregroundColor(textPrimary)
@@ -286,7 +347,7 @@ struct ActiveRecordingView: View {
                     .foregroundColor(textSecondary)
             }
 
-            HStack(spacing: 4) {
+            HStack(spacing: AppTheme.Spacing.xs) {
                 Image(systemName: icon)
                     .font(.caption)
                 Text(label)
@@ -295,15 +356,81 @@ struct ActiveRecordingView: View {
             .foregroundColor(textSecondary)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 16)
+        .padding(.vertical, AppTheme.Spacing.lg)
         .background(
-            RoundedRectangle(cornerRadius: 16)
+            RoundedRectangle(cornerRadius: AppTheme.CornerRadius.large)
                 .fill(themeManager.isDarkMode ? Color.white.opacity(0.08) : Color.black.opacity(0.04))
         )
     }
 
+    /// Expandable primary metric card with tap-to-reveal additional context
+    @ViewBuilder
+    private func expandablePrimaryMetricCard<Content: View>(
+        value: String,
+        unit: String,
+        label: String,
+        icon: String,
+        metric: ExpandedMetric,
+        @ViewBuilder expandedContent: () -> Content
+    ) -> some View {
+        let isExpanded = expandedMetric == metric
+
+        VStack(spacing: AppTheme.Spacing.sm) {
+            // Main metric display
+            HStack(alignment: .lastTextBaseline, spacing: AppTheme.Spacing.xs) {
+                Text(value)
+                    .font(.system(size: 32, weight: .bold, design: .rounded))
+                    .foregroundColor(textPrimary)
+                    .monospacedDigit()
+                Text(unit)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundColor(textSecondary)
+            }
+
+            // Label with expand indicator
+            HStack(spacing: AppTheme.Spacing.xs) {
+                Image(systemName: icon)
+                    .font(.caption)
+                Text(label)
+                    .font(.caption)
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundColor(textTertiary)
+            }
+            .foregroundColor(textSecondary)
+
+            // Expanded content with animation
+            if isExpanded {
+                Divider()
+                    .background(textTertiary.opacity(0.3))
+                    .padding(.horizontal, AppTheme.Spacing.md)
+
+                expandedContent()
+                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, AppTheme.Spacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: AppTheme.CornerRadius.large)
+                .fill(themeManager.isDarkMode ? Color.white.opacity(isExpanded ? 0.12 : 0.08) : Color.black.opacity(isExpanded ? 0.06 : 0.04))
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            impactFeedback.impactOccurred()
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                if expandedMetric == metric {
+                    expandedMetric = nil
+                } else {
+                    expandedMetric = metric
+                }
+            }
+        }
+    }
+
     private func secondaryMetricCard(value: String, label: String) -> some View {
-        VStack(spacing: 4) {
+        VStack(spacing: AppTheme.Spacing.xs) {
             Text(value)
                 .font(.headline)
                 .fontWeight(.semibold)
@@ -314,9 +441,9 @@ struct ActiveRecordingView: View {
                 .foregroundColor(textSecondary)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 12)
+        .padding(.vertical, AppTheme.Spacing.md)
         .background(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: AppTheme.CornerRadius.medium)
                 .fill(themeManager.isDarkMode ? Color.white.opacity(0.05) : Color.black.opacity(0.03))
         )
     }
@@ -324,33 +451,36 @@ struct ActiveRecordingView: View {
     // MARK: - Auto Pause Indicator
 
     private var autoPauseIndicator: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: AppTheme.Spacing.sm) {
             Image(systemName: "pause.circle.fill")
                 .foregroundColor(.orange)
             Text("Auto-paused - Start moving to resume")
                 .font(.subheadline)
                 .foregroundColor(textSecondary)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
+        .padding(.horizontal, AppTheme.Spacing.lg)
+        .padding(.vertical, AppTheme.Spacing.md)
         .background(
-            RoundedRectangle(cornerRadius: 10)
+            RoundedRectangle(cornerRadius: AppTheme.CornerRadius.medium)
                 .fill(Color.orange.opacity(0.15))
         )
-        .padding(.horizontal, 20)
+        .padding(.horizontal, AppTheme.Spacing.xl)
     }
 
     // MARK: - Control Buttons
 
     private var controlButtons: some View {
-        HStack(spacing: 24) {
+        HStack(spacing: AppTheme.Spacing.xxl) {
             // Pause/Resume button
             Button(action: togglePauseResume) {
-                VStack(spacing: 6) {
+                VStack(spacing: AppTheme.Spacing.xs) {
                     Image(systemName: pauseResumeIcon)
                         .font(.title)
                         .foregroundColor(.white)
-                        .frame(width: 80, height: 80)
+                        .frame(
+                            width: AppTheme.Layout.touchTargetMotionPreferred,
+                            height: AppTheme.Layout.touchTargetMotionPreferred
+                        )
                         .background(pauseResumeColor, in: Circle())
                         .shadow(color: pauseResumeColor.opacity(0.4), radius: 10, x: 0, y: 4)
 
@@ -365,11 +495,14 @@ struct ActiveRecordingView: View {
 
             // Stop button
             Button(action: triggerStopConfirmation) {
-                VStack(spacing: 6) {
+                VStack(spacing: AppTheme.Spacing.xs) {
                     Image(systemName: "stop.fill")
                         .font(.title)
                         .foregroundColor(.white)
-                        .frame(width: 80, height: 80)
+                        .frame(
+                            width: AppTheme.Layout.touchTargetMotionPreferred,
+                            height: AppTheme.Layout.touchTargetMotionPreferred
+                        )
                         .background(.red, in: Circle())
                         .shadow(color: Color.red.opacity(0.4), radius: 10, x: 0, y: 4)
 
@@ -380,7 +513,7 @@ struct ActiveRecordingView: View {
                 }
             }
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, AppTheme.Spacing.xl)
     }
     
     // MARK: - Computed Properties

--- a/Runaway iOS/Views/ActiveRecordingView.swift
+++ b/Runaway iOS/Views/ActiveRecordingView.swift
@@ -7,8 +7,12 @@
 
 import SwiftUI
 import CoreLocation
+import UIKit
 
 struct ActiveRecordingView: View {
+    // MARK: - Haptic Feedback
+    private let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
+    private let notificationFeedback = UINotificationFeedbackGenerator()
     @ObservedObject var recordingService: ActivityRecordingService
     let activityType: String
     let customName: String
@@ -360,7 +364,7 @@ struct ActiveRecordingView: View {
                     Image(systemName: pauseResumeIcon)
                         .font(.title)
                         .foregroundColor(.white)
-                        .frame(width: 70, height: 70)
+                        .frame(width: 80, height: 80)
                         .background(pauseResumeColor, in: Circle())
                         .shadow(color: pauseResumeColor.opacity(0.4), radius: 10, x: 0, y: 4)
 
@@ -374,14 +378,12 @@ struct ActiveRecordingView: View {
             .opacity(recordingService.isAutopaused ? 0.5 : 1.0)
 
             // Stop button
-            Button(action: {
-                showingStopConfirmation = true
-            }) {
+            Button(action: triggerStopConfirmation) {
                 VStack(spacing: 6) {
                     Image(systemName: "stop.fill")
                         .font(.title)
                         .foregroundColor(.white)
-                        .frame(width: 70, height: 70)
+                        .frame(width: 80, height: 80)
                         .background(.red, in: Circle())
                         .shadow(color: Color.red.opacity(0.4), radius: 10, x: 0, y: 4)
 
@@ -433,6 +435,7 @@ struct ActiveRecordingView: View {
     // MARK: - Methods
 
     private func togglePauseResume() {
+        impactFeedback.impactOccurred()
         switch recordingService.state {
         case .recording:
             recordingService.pauseRecording()
@@ -444,13 +447,20 @@ struct ActiveRecordingView: View {
     }
 
     private func stopRecording() {
+        notificationFeedback.notificationOccurred(.success)
         recordingService.stopRecording()
         showingPostRecording = true
     }
 
     private func discardRecording() {
+        notificationFeedback.notificationOccurred(.warning)
         recordingService.discardRecording()
         dismiss()
+    }
+
+    private func triggerStopConfirmation() {
+        impactFeedback.impactOccurred()
+        showingStopConfirmation = true
     }
 
     private func formatTime(_ time: TimeInterval) -> String {

--- a/Runaway iOS/Views/ActiveRecordingView.swift
+++ b/Runaway iOS/Views/ActiveRecordingView.swift
@@ -29,13 +29,6 @@ struct ActiveRecordingView: View {
     // @StateObject private var audioCoaching = AudioCoachingService()
     private let audioCoachingEnabled = false
 
-    // Activities that require GPS tracking
-    private let gpsActivities = ["run", "walk", "ride", "hike", "swim", "bike", "cycling"]
-
-    private var needsGPS: Bool {
-        gpsActivities.contains(activityType.lowercased())
-    }
-
     private var activityIcon: String {
         switch activityType.lowercased() {
         case "run": return "figure.run"
@@ -264,7 +257,7 @@ struct ActiveRecordingView: View {
                 )
             }
 
-            // Secondary metrics row
+            // Secondary metrics row (max 2 for glanceability)
             HStack(spacing: 12) {
                 secondaryMetricCard(
                     value: UnitFormatter.formatPaceTime(minutesPerMile: recordingService.gpsService.averagePace),
@@ -275,13 +268,6 @@ struct ActiveRecordingView: View {
                     value: UnitFormatter.formatSpeedValue(recordingService.gpsService.currentSpeed),
                     label: "Speed (\(UnitFormatter.speedUnitLabel))"
                 )
-
-                if needsGPS {
-                    secondaryMetricCard(
-                        value: "\(recordingService.gpsService.routePoints.count)",
-                        label: "GPS Points"
-                    )
-                }
             }
         }
         .padding(.horizontal, 20)

--- a/Runaway iOS/Views/ActivitiesView.swift
+++ b/Runaway iOS/Views/ActivitiesView.swift
@@ -53,6 +53,10 @@ struct ActivitiesView: View {
                     } else {
                         ScrollView {
                             VStack(spacing: AppTheme.Spacing.lg) {
+                                // Weekly Stats Card (shows goal even with 0 activities)
+                                WeeklyStatsCard()
+                                    .padding(.horizontal, AppTheme.Spacing.md)
+
                                 // Activity Commitment Card
                                 ActivityCommitmentCard()
                                     .padding(.horizontal, AppTheme.Spacing.md)
@@ -66,6 +70,10 @@ struct ActivitiesView: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: AppTheme.Spacing.md) {
+                            // Weekly Stats Card (Tier 2 - Quick View)
+                            WeeklyStatsCard()
+                                .padding(.horizontal, AppTheme.Spacing.md)
+
                             // Activity Commitment Card
                             ActivityCommitmentCard()
                                 .padding(.horizontal, AppTheme.Spacing.md)

--- a/Runaway iOS/Views/ActivitiesView.swift
+++ b/Runaway iOS/Views/ActivitiesView.swift
@@ -9,13 +9,12 @@ struct ActivitiesView: View {
     @EnvironmentObject var realtimeService: RealtimeService
     @EnvironmentObject var themeManager: ThemeManager
     @State private var selectedActivity: LocalActivity?
-    @State private var showingRecording = false
 
     private var colors: (background: Color, textPrimary: Color, textSecondary: Color) {
         if themeManager.isDarkMode {
             return (AppTheme.Colors.DarkMode.background, AppTheme.Colors.DarkMode.textPrimary, AppTheme.Colors.DarkMode.textSecondary)
         } else {
-            return (ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.background : AppTheme.Colors.LightMode.background, ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textPrimary : AppTheme.Colors.LightMode.textPrimary, ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary)
+            return (AppTheme.Colors.LightMode.background, AppTheme.Colors.LightMode.textPrimary, AppTheme.Colors.LightMode.textSecondary)
         }
     }
 
@@ -53,12 +52,8 @@ struct ActivitiesView: View {
                     } else {
                         ScrollView {
                             VStack(spacing: AppTheme.Spacing.lg) {
-                                // Weekly Stats Card (shows goal even with 0 activities)
-                                WeeklyStatsCard()
-                                    .padding(.horizontal, AppTheme.Spacing.md)
-
-                                // Activity Commitment Card
-                                ActivityCommitmentCard()
+                                // Compact Commitment Card
+                                CompactCommitmentCard()
                                     .padding(.horizontal, AppTheme.Spacing.md)
 
                                 // Empty state
@@ -70,12 +65,8 @@ struct ActivitiesView: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: AppTheme.Spacing.md) {
-                            // Weekly Stats Card (Tier 2 - Quick View)
-                            WeeklyStatsCard()
-                                .padding(.horizontal, AppTheme.Spacing.md)
-
-                            // Activity Commitment Card
-                            ActivityCommitmentCard()
+                            // Compact Commitment Card
+                            CompactCommitmentCard()
                                 .padding(.horizontal, AppTheme.Spacing.md)
 
                             // Activities List
@@ -101,38 +92,11 @@ struct ActivitiesView: View {
                     }
                 }
             }
-            
-            // Floating Action Button
-            VStack {
-                Spacer()
-                HStack {
-                    Spacer()
-                    Button(action: {
-                        showingRecording = true
-                    }) {
-                        Image(systemName: "plus")
-                            .font(.title2)
-                            .fontWeight(.semibold)
-                            .foregroundColor(.black)
-                            .frame(width: AppTheme.Layout.fabSize, height: AppTheme.Layout.fabSize)
-                            .background(AppTheme.Colors.accentGradient)
-                            .clipShape(Circle())
-                            .themeShadow(.accentGlow)
-                    }
-                    .accessibilityLabel("Start new activity")
-                    .accessibilityHint("Double tap to begin recording a workout")
-                    .padding(.trailing, AppTheme.Layout.fabOffset)
-                    .padding(.bottom, AppTheme.Layout.fabOffset)
-                }
-            }
-            
+
             .sheet(item: $selectedActivity) { activity in
                 NavigationView {
                     ActivityDetailView(activity: activity)
                 }
-            }
-            .fullScreenCover(isPresented: $showingRecording) {
-                PreRecordingView()
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {

--- a/Runaway iOS/Views/AthleteView.swift
+++ b/Runaway iOS/Views/AthleteView.swift
@@ -42,7 +42,7 @@ struct AthleteView: View {
                     
                     // Detailed Stats Cards
                     LazyVStack(spacing: AppTheme.Spacing.md) {
-                        WeeklyStatsCard(stats: stats)
+                        AthleteWeeklyStatsCard(stats: stats)
                         MonthlyStatsCard(stats: stats)
                         AllTimeStatsCard(stats: stats)
                     }
@@ -178,8 +178,8 @@ struct QuickStatItem: View {
     }
 }
 
-// MARK: - Weekly Stats Card
-struct WeeklyStatsCard: View {
+// MARK: - Athlete Weekly Stats Card
+struct AthleteWeeklyStatsCard: View {
     @ObservedObject private var themeManager = ThemeManager.shared
 
     let stats: AthleteStats

--- a/Runaway iOS/Views/MainView.swift
+++ b/Runaway iOS/Views/MainView.swift
@@ -16,147 +16,77 @@ struct MainView: View {
     @Environment(AppRouter.self) private var router
     @State var selectedTab = 0
     @State var isDataReady: Bool = false
+    @State private var showRecording = false
 
     private var toolbarScheme: ColorScheme {
         themeManager.isDarkMode ? .dark : .light
     }
 
+    private var backgroundColor: Color {
+        themeManager.isDarkMode ? AppTheme.Colors.DarkMode.background : AppTheme.Colors.LightMode.background
+    }
+
     var body: some View {
         if isDataReady {
-            TabView(selection: $selectedTab) {
-                NavigationStack(path: Bindable(router).path) {
-                    ActivitiesView()
-                        .navigationTitle("Log Book")
-                        .navigationBarTitleDisplayMode(.large)
-                        .toolbarColorScheme(toolbarScheme, for: .navigationBar)
-                        .toolbarBackground(.visible, for: .navigationBar)
-                        .navigationDestination(for: AppRouter.Route.self) { route in
-                            router.destination(for: route)
-                        }
-                }
-                .tabItem {
-                    Label("Feed", systemImage: "newspaper")
-                }
-                .tag(0)
-
-                NavigationStack(path: Bindable(router).path) {
-                    TrainingView()
-                        .toolbarColorScheme(toolbarScheme, for: .navigationBar)
-                        .toolbarBackground(.visible, for: .navigationBar)
-                        .navigationDestination(for: AppRouter.Route.self) { route in
-                            router.destination(for: route)
-                        }
-                }
-                .tabItem {
-                    Label("Performance", systemImage: "chart.bar.fill")
-                }
-                .tag(1)
-
-                NavigationStack(path: Bindable(router).path) {
-                    PlanView()
-                        .environmentObject(dataManager)
-                        .toolbarColorScheme(toolbarScheme, for: .navigationBar)
-                        .toolbarBackground(.visible, for: .navigationBar)
-                        .navigationDestination(for: AppRouter.Route.self) { route in
-                            router.destination(for: route)
-                        }
-                }
-                .tabItem {
-                    Label("Plan", systemImage: "calendar.badge.clock")
-                }
-                .tag(2)
-
-                NavigationStack(path: Bindable(router).path) {
-                    ResearchView()
-                        .toolbarColorScheme(toolbarScheme, for: .navigationBar)
-                        .toolbarBackground(.visible, for: .navigationBar)
-                        .navigationDestination(for: AppRouter.Route.self) { route in
-                            router.destination(for: route)
-                        }
-                }
-                .tabItem {
-                    Label("Research", systemImage: "flask")
-                }
-                .tag(3)
-
-                NavigationStack(path: Bindable(router).path) {
-                    Group {
-                        if let athlete = dataManager.athlete, let stats = dataManager.stats {
-                            AthleteView(athlete: athlete, stats: stats)
-                                .navigationTitle("Profile")
+            ZStack(alignment: .bottom) {
+                // Tab Content
+                Group {
+                    switch selectedTab {
+                    case 0:
+                        NavigationStack(path: Bindable(router).path) {
+                            ActivitiesView()
+                                .navigationTitle("Activities")
                                 .navigationBarTitleDisplayMode(.large)
-                                .toolbar {
-                                    ToolbarItem(placement: .navigationBarTrailing) {
-                                        Button(action: {
-                                            router.navigate(to: .settings)
-                                        }) {
-                                            Image(systemName: "gearshape.fill")
-                                                .foregroundColor(AppTheme.Colors.accent)
-                                        }
-                                    }
+                                .toolbarColorScheme(toolbarScheme, for: .navigationBar)
+                                .toolbarBackground(.visible, for: .navigationBar)
+                                .navigationDestination(for: AppRouter.Route.self) { route in
+                                    router.destination(for: route)
                                 }
-                        } else if dataManager.isLoadingAthlete {
-                            // Still loading - show spinner
-                            VStack(spacing: AppTheme.Spacing.md) {
-                                ProgressView()
-                                    .scaleEffect(1.2)
-                                    .progressViewStyle(CircularProgressViewStyle(tint: AppTheme.Colors.accent))
-                                Text("Loading profile...")
-                                    .font(AppTheme.Typography.body)
-                                    .foregroundColor(themeManager.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary)
-                            }
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .background(themeManager.isDarkMode ? AppTheme.Colors.DarkMode.background : AppTheme.Colors.LightMode.background)
-                            .navigationTitle("Profile")
-                            .navigationBarTitleDisplayMode(.large)
-                            .toolbar {
-                                ToolbarItem(placement: .navigationBarTrailing) {
-                                    Button(action: {
-                                        router.navigate(to: .settings)
-                                    }) {
-                                        Image(systemName: "gearshape.fill")
-                                            .foregroundColor(AppTheme.Colors.accent)
-                                    }
-                                }
-                            }
-                        } else {
-                            // Done loading but no profile - attempt reload
-                            ProfileLoadingErrorView(onRetry: {
-                                Task {
-                                    if let userId = userSession.userId {
-                                        await dataManager.loadAllData(for: userId)
-                                    }
-                                }
-                            })
-                            .navigationTitle("Profile")
-                            .navigationBarTitleDisplayMode(.large)
-                            .toolbar {
-                                ToolbarItem(placement: .navigationBarTrailing) {
-                                    Button(action: {
-                                        router.navigate(to: .settings)
-                                    }) {
-                                        Image(systemName: "gearshape.fill")
-                                            .foregroundColor(AppTheme.Colors.accent)
-                                    }
-                                }
-                            }
                         }
-                    }
-                    .toolbarColorScheme(toolbarScheme, for: .navigationBar)
-                    .toolbarBackground(.visible, for: .navigationBar)
-                    .navigationDestination(for: AppRouter.Route.self) { route in
-                        router.destination(for: route)
+                    case 1:
+                        NavigationStack(path: Bindable(router).path) {
+                            TrainingView()
+                                .toolbarColorScheme(toolbarScheme, for: .navigationBar)
+                                .toolbarBackground(.visible, for: .navigationBar)
+                                .navigationDestination(for: AppRouter.Route.self) { route in
+                                    router.destination(for: route)
+                                }
+                        }
+                    case 3:
+                        NavigationStack(path: Bindable(router).path) {
+                            PlanView()
+                                .environmentObject(dataManager)
+                                .toolbarColorScheme(toolbarScheme, for: .navigationBar)
+                                .toolbarBackground(.visible, for: .navigationBar)
+                                .navigationDestination(for: AppRouter.Route.self) { route in
+                                    router.destination(for: route)
+                                }
+                        }
+                    case 4:
+                        NavigationStack(path: Bindable(router).path) {
+                            profileContent
+                                .toolbarColorScheme(toolbarScheme, for: .navigationBar)
+                                .toolbarBackground(.visible, for: .navigationBar)
+                                .navigationDestination(for: AppRouter.Route.self) { route in
+                                    router.destination(for: route)
+                                }
+                        }
+                    default:
+                        // Tab 2 is Record - handled by showRecording
+                        EmptyView()
                     }
                 }
-                .tabItem {
-                    Label("Profile", systemImage: "person.fill")
-                }
-                .tag(4)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.bottom, 80) // Space for custom tab bar
+
+                // Custom Tab Bar
+                CustomTabBar(selectedTab: $selectedTab, showRecording: $showRecording)
             }
-            .accentColor(AppTheme.Colors.accent)
+            .ignoresSafeArea(.keyboard)
+            .background(backgroundColor)
             .onChange(of: selectedTab) { oldTab, newTab in
                 // Track tab selection analytics
-                let tabNames = ["Feed", "Performance", "Plan", "Research", "Profile"]
+                let tabNames = ["Activities", "Progress", "Record", "Plan", "Profile"]
                 let tabName = newTab < tabNames.count ? tabNames[newTab] : "Unknown"
                 AnalyticsService.shared.track(.tabSelected, category: .navigation, properties: [
                     "tab_name": tabName,
@@ -164,11 +94,19 @@ struct MainView: View {
                     "previous_tab": oldTab
                 ])
             }
+            .fullScreenCover(isPresented: $showRecording) {
+                PreRecordingView()
+            }
+            .onChange(of: showRecording) { wasShowing, isShowing in
+                // Return to Activities tab after recording is dismissed
+                if wasShowing && !isShowing {
+                    selectedTab = 0
+                }
+            }
             .task {
                 await loadInitialData()
                 realtimeService.startRealtimeSubscription()
             }
-            .background((themeManager.isDarkMode ? AppTheme.Colors.DarkMode.background : ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.background : AppTheme.Colors.LightMode.background).ignoresSafeArea())
         } else {
             ZStack {
                 (themeManager.isDarkMode ? AppTheme.Colors.DarkMode.background : ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.background : AppTheme.Colors.LightMode.background)
@@ -205,6 +143,74 @@ struct MainView: View {
             }
             .task {
                 await loadInitialData()
+            }
+        }
+    }
+
+    // MARK: - Profile Content
+
+    @ViewBuilder
+    private var profileContent: some View {
+        Group {
+            if let athlete = dataManager.athlete, let stats = dataManager.stats {
+                AthleteView(athlete: athlete, stats: stats)
+                    .navigationTitle("Profile")
+                    .navigationBarTitleDisplayMode(.large)
+                    .toolbar {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            Button(action: {
+                                router.navigate(to: .settings)
+                            }) {
+                                Image(systemName: "gearshape.fill")
+                                    .foregroundColor(AppTheme.Colors.accent)
+                            }
+                        }
+                    }
+            } else if dataManager.isLoadingAthlete {
+                // Still loading - show spinner
+                VStack(spacing: AppTheme.Spacing.md) {
+                    ProgressView()
+                        .scaleEffect(1.2)
+                        .progressViewStyle(CircularProgressViewStyle(tint: AppTheme.Colors.accent))
+                    Text("Loading profile...")
+                        .font(AppTheme.Typography.body)
+                        .foregroundColor(themeManager.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(backgroundColor)
+                .navigationTitle("Profile")
+                .navigationBarTitleDisplayMode(.large)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button(action: {
+                            router.navigate(to: .settings)
+                        }) {
+                            Image(systemName: "gearshape.fill")
+                                .foregroundColor(AppTheme.Colors.accent)
+                        }
+                    }
+                }
+            } else {
+                // Done loading but no profile - attempt reload
+                ProfileLoadingErrorView(onRetry: {
+                    Task {
+                        if let userId = userSession.userId {
+                            await dataManager.loadAllData(for: userId)
+                        }
+                    }
+                })
+                .navigationTitle("Profile")
+                .navigationBarTitleDisplayMode(.large)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button(action: {
+                            router.navigate(to: .settings)
+                        }) {
+                            Image(systemName: "gearshape.fill")
+                                .foregroundColor(AppTheme.Colors.accent)
+                        }
+                    }
+                }
             }
         }
     }

--- a/Runaway iOS/Views/PlanView.swift
+++ b/Runaway iOS/Views/PlanView.swift
@@ -4,14 +4,23 @@
 //
 //  Dynamic training plan view - the Plan tab
 //  Shows adaptive weekly plans that update based on recent workouts
+//  Now includes segmented control for Training and Research sections
 //
 
 import SwiftUI
+
+// MARK: - Plan Section Enum
+
+enum PlanSection: String, CaseIterable {
+    case training = "Training"
+    case research = "Research"
+}
 
 struct PlanView: View {
     @EnvironmentObject var dataManager: DataManager
     @EnvironmentObject var themeManager: ThemeManager
     @StateObject private var viewModel = PlanViewModel()
+    @State private var selectedSection: PlanSection = .training
     @State private var showingWorkoutDetail: DailyWorkout?
     @State private var showingGenerateConfirmation = false
     @State private var showingTrainingGuidelines = false
@@ -27,16 +36,67 @@ struct PlanView: View {
             )
         } else {
             return (
-                ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.background : AppTheme.Colors.LightMode.background,
-                ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.cardBackground : AppTheme.Colors.LightMode.cardBackground,
-                ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textPrimary : AppTheme.Colors.LightMode.textPrimary,
-                ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.textSecondary : AppTheme.Colors.LightMode.textSecondary,
-                ThemeManager.shared.isDarkMode ? AppTheme.Colors.DarkMode.surfaceBackground : AppTheme.Colors.LightMode.surfaceBackground
+                AppTheme.Colors.LightMode.background,
+                AppTheme.Colors.LightMode.cardBackground,
+                AppTheme.Colors.LightMode.textPrimary,
+                AppTheme.Colors.LightMode.textSecondary,
+                AppTheme.Colors.LightMode.surfaceBackground
             )
         }
     }
 
     var body: some View {
+        VStack(spacing: 0) {
+            // Segmented Control
+            Picker("Section", selection: $selectedSection) {
+                ForEach(PlanSection.allCases, id: \.self) { section in
+                    Text(section.rawValue).tag(section)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+            .padding(.top, AppTheme.Spacing.sm)
+            .padding(.bottom, AppTheme.Spacing.sm)
+
+            // Content based on selection
+            switch selectedSection {
+            case .training:
+                trainingContent
+            case .research:
+                ResearchContentView()
+                    .environmentObject(themeManager)
+            }
+        }
+        .background(colors.background)
+        .navigationTitle("Plan")
+        .navigationBarTitleDisplayMode(.large)
+        .toolbarColorScheme(themeManager.isDarkMode ? .dark : .light, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                if selectedSection == .training {
+                    Button(action: { showingTrainingGuidelines = true }) {
+                        Image(systemName: "info.circle")
+                            .foregroundColor(AppTheme.Colors.accent)
+                    }
+                    .accessibilityLabel("Training Guidelines")
+                }
+            }
+        }
+        .sheet(item: $showingWorkoutDetail) { workout in
+            PlanWorkoutDetailSheet(workout: workout)
+        }
+        .sheet(isPresented: $showingTrainingGuidelines) {
+            TrainingGuidelinesSheet()
+        }
+        .task {
+            await viewModel.loadPlan()
+        }
+    }
+
+    // MARK: - Training Content
+
+    @ViewBuilder
+    private var trainingContent: some View {
         ScrollView {
             VStack(spacing: AppTheme.Spacing.lg) {
                 if viewModel.isLoading {
@@ -97,30 +157,8 @@ struct PlanView: View {
             }
             .padding()
         }
-        .background(colors.background)
-        .navigationTitle("Training Plan")
-        .navigationBarTitleDisplayMode(.large)
-        .toolbarColorScheme(themeManager.isDarkMode ? .dark : .light, for: .navigationBar)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: { showingTrainingGuidelines = true }) {
-                    Image(systemName: "info.circle")
-                        .foregroundColor(AppTheme.Colors.accent)
-                }
-                .accessibilityLabel("Training Guidelines")
-            }
-        }
         .refreshable {
             await viewModel.refresh()
-        }
-        .sheet(item: $showingWorkoutDetail) { workout in
-            PlanWorkoutDetailSheet(workout: workout)
-        }
-        .sheet(isPresented: $showingTrainingGuidelines) {
-            TrainingGuidelinesSheet()
-        }
-        .task {
-            await viewModel.loadPlan()
         }
     }
 }

--- a/Runaway iOS/Views/ResearchContentView.swift
+++ b/Runaway iOS/Views/ResearchContentView.swift
@@ -1,0 +1,180 @@
+//
+//  ResearchContentView.swift
+//  Runaway iOS
+//
+//  Embeddable version of ResearchView for nesting inside PlanView
+//
+
+import SwiftUI
+import CoreLocation
+
+struct ResearchContentView: View {
+    @EnvironmentObject var themeManager: ThemeManager
+    @StateObject private var researchService = ResearchService()
+    @ObservedObject private var locationManager = LocationManager.shared
+    @State private var selectedCategory: ArticleCategory? = nil
+    @State private var selectedArticle: ResearchArticle?
+    @State private var filteredArticles: [ResearchArticle] = []
+
+    private var colors: (background: Color, cardBg: Color, textPrimary: Color, textSecondary: Color, textTertiary: Color, surface: Color) {
+        if themeManager.isDarkMode {
+            return (
+                AppTheme.Colors.DarkMode.background,
+                AppTheme.Colors.DarkMode.cardBackground,
+                AppTheme.Colors.DarkMode.textPrimary,
+                AppTheme.Colors.DarkMode.textSecondary,
+                AppTheme.Colors.DarkMode.textTertiary,
+                AppTheme.Colors.DarkMode.surfaceBackground
+            )
+        } else {
+            return (
+                AppTheme.Colors.LightMode.background,
+                AppTheme.Colors.LightMode.cardBackground,
+                AppTheme.Colors.LightMode.textPrimary,
+                AppTheme.Colors.LightMode.textSecondary,
+                AppTheme.Colors.LightMode.textTertiary,
+                AppTheme.Colors.LightMode.surfaceBackground
+            )
+        }
+    }
+
+    private func updateFilteredArticles() {
+        if let category = selectedCategory {
+            filteredArticles = researchService.articles.filter { $0.category == category }
+        } else {
+            filteredArticles = researchService.articles
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                // Refresh button row
+                HStack {
+                    Spacer()
+                    Button(action: {
+                        Task {
+                            await loadArticles()
+                        }
+                    }) {
+                        HStack(spacing: 6) {
+                            Image(systemName: "arrow.clockwise")
+                                .rotationEffect(.degrees(researchService.isLoading ? 360 : 0))
+                                .animation(researchService.isLoading ? .linear(duration: 1).repeatForever(autoreverses: false) : .default, value: researchService.isLoading)
+                            Text("Refresh")
+                                .font(AppTheme.Typography.caption)
+                        }
+                        .foregroundColor(AppTheme.Colors.accent)
+                    }
+                    .disabled(researchService.isLoading)
+                }
+                .padding(.horizontal)
+                .padding(.top, AppTheme.Spacing.sm)
+
+                // Category Filter Pills
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        CategoryPill(
+                            title: "All",
+                            count: researchService.articles.count,
+                            isSelected: selectedCategory == nil,
+                            isDarkMode: themeManager.isDarkMode,
+                            action: { selectedCategory = nil }
+                        )
+
+                        ForEach(ArticleCategory.allCases, id: \.self) { category in
+                            let categoryCount = researchService.articles.filter { $0.category == category }.count
+                            CategoryPill(
+                                title: category.displayName,
+                                count: categoryCount,
+                                isSelected: selectedCategory == category,
+                                isDarkMode: themeManager.isDarkMode,
+                                action: { selectedCategory = category }
+                            )
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+                .padding(.vertical, 8)
+
+                // Loading State
+                if researchService.isLoading && researchService.articles.isEmpty {
+                    LoadingView()
+                        .frame(height: 200)
+                }
+
+                // Error Message
+                if let errorMessage = researchService.errorMessage {
+                    ErrorView(message: errorMessage) {
+                        Task {
+                            await loadArticles()
+                        }
+                    }
+                    .padding()
+                }
+
+                // Mixed Articles and Videos
+                if !filteredArticles.isEmpty {
+                    ForEach(Array(filteredArticles.enumerated()), id: \.offset) { index, article in
+                        ArticleCard(article: article, isDarkMode: themeManager.isDarkMode) {
+                            selectedArticle = article
+                        }
+                        .padding(.horizontal)
+                        .padding(.bottom, 12)
+                    }
+                } else if !researchService.isLoading {
+                    EmptyStateView(isDarkMode: themeManager.isDarkMode)
+                        .padding()
+                }
+
+                // Last Updated
+                if let lastUpdated = researchService.lastUpdated {
+                    Text("Last updated: \(lastUpdated, formatter: RelativeDateTimeFormatter())")
+                        .font(AppTheme.Typography.caption)
+                        .foregroundColor(colors.textSecondary)
+                        .padding(.vertical)
+                }
+            }
+        }
+        .refreshable {
+            await loadArticles()
+        }
+        .task {
+            await loadArticles()
+        }
+        .onReceive(locationManager.$location) { _ in
+            Task {
+                await loadArticles()
+            }
+        }
+        .onReceive(researchService.$articles) { _ in
+            updateFilteredArticles()
+        }
+        .onChange(of: selectedCategory) { _, _ in
+            updateFilteredArticles()
+        }
+        .onAppear {
+            updateFilteredArticles()
+        }
+        .sheet(item: $selectedArticle) { article in
+            ArticleWebView(article: article)
+        }
+    }
+
+    private func loadArticles() async {
+        let searchParams = ResearchSearchParams(
+            categories: ArticleCategory.allCases,
+            userLocation: locationManager.location,
+            radiusMiles: 50.0,
+            maxArticles: 50,
+            daysBack: 7
+        )
+
+        _ = await researchService.fetchResearchArticles(params: searchParams)
+    }
+}
+
+#Preview {
+    ResearchContentView()
+        .environmentObject(ThemeManager.shared)
+}

--- a/Runaway iOS/Views/TrainingView.swift
+++ b/Runaway iOS/Views/TrainingView.swift
@@ -63,6 +63,9 @@ struct TrainingView: View {
             } else {
                 ScrollView {
                     VStack(spacing: 16) {
+                        // 0. Weekly Stats Card (moved from Activities)
+                        WeeklyStatsCard()
+
                         // 1. Adaptive Primary Insight (phase-aware dashboard)
                         if let phaseContext = viewModel.trainingPhaseContext {
                             AdaptivePrimaryInsightCard(
@@ -129,7 +132,7 @@ struct TrainingView: View {
                 }
             }
         }
-        .navigationTitle("Performance")
+        .navigationTitle("Progress")
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
             #if DEBUG

--- a/RunawayWidget/RunawayWidget.swift
+++ b/RunawayWidget/RunawayWidget.swift
@@ -81,19 +81,19 @@ struct BarChart: View {
         days.contains { $0.minutes > 0 }
     }
 
-    // Array of fun empty state messages
+    // Array of encouraging empty state messages (non-judgmental)
     private var emptyStateMessages: [String] {
         [
-            "You better be lacing up your sneakers...",
-            "Those running shoes are looking lonely 👟",
-            "Time to turn those couch miles into real miles!",
-            "Your sneakers are gathering dust...",
-            "The pavement is calling your name!",
-            "Zero miles? Time to change that! 🏃‍♀️",
-            "Your weekly chart is thirsty for some data!",
-            "Ready to paint this chart with some miles?",
-            "Empty bars = time for full effort! 💪",
-            "This chart needs some serious activity love!"
+            "Fresh week, fresh start",
+            "Your next run awaits",
+            "Rest is part of training too",
+            "Ready when you are",
+            "A new week of possibilities",
+            "Every journey starts with one step",
+            "Today is a great day for a run",
+            "Your chart is ready for new adventures",
+            "Take it one day at a time",
+            "Good things come to those who move"
         ]
     }
 

--- a/RunawayWidget/RunawayWidget.swift
+++ b/RunawayWidget/RunawayWidget.swift
@@ -465,11 +465,11 @@ struct RunawayWidgetEntryView : View {
                 Spacer()
                 VStack{
                     PieChartView(current: weeklyMileage, goalRemaining: max(0, entry.weeklyGoal - weeklyMileage), color: Color(red: 0.2, green: 0.6, blue: 1.0)).padding(.bottom,2)
-                    Text("Weekly \(WidgetUnitHelper.unitAbbreviation)").font(.system(size: 8, weight: .heavy)).foregroundColor(.white)
+                    Text("Weekly \(WidgetUnitHelper.unitAbbreviation)").font(.system(size: 10, weight: .heavy)).foregroundColor(.white)
                 }.padding(.bottom,8)
                 VStack{
                     PieChartView(current: entry.monthlyMiles, goalRemaining: max(0, entry.monthlyGoal - entry.monthlyMiles), color: Color(red: 0.4, green: 0.8, blue: 0.4)).padding(.bottom,2)
-                    Text("Monthly \(WidgetUnitHelper.unitAbbreviation)").font(.system(size: 8, weight: .heavy)).foregroundColor(.white)
+                    Text("Monthly \(WidgetUnitHelper.unitAbbreviation)").font(.system(size: 10, weight: .heavy)).foregroundColor(.white)
                 }.padding(.bottom,8)
             }.padding(.top, 16)
             HStack(alignment: .bottom){


### PR DESCRIPTION
## Summary

Major UX overhaul focused on cleaner navigation, streamlined commitment flow, and improved visual design.

### Tab Bar Restructure
- Replaced standard TabView with custom tab bar featuring prominent center Record button
- Renamed tabs: Feed → Activities, Performance → Progress
- Nested Research inside Plan tab with segmented control
- Record button opens PreRecordingView as fullScreenCover, returns to Activities on dismiss

### Commitment Card Redesign
- New `CompactCommitmentCard` with condensed single-row layout for Activities tab
- Streamlined flow: tapping "Set Today's Commitment" goes directly to activity picker (fewer steps)
- Redesigned `FullCommitmentSheet` with modern hero layout:
  - Large activity icon
  - "You're committed to [Activity] today" messaging
  - Clean change/remove actions

### Daily Goals Feature
- Optional distance or time goals for commitments
- Goals persist to UserDefaults via `DailyGoalStore`
- Auto-clear at midnight (goals don't carry over)
- Goals display inline on compact card: "Today: Run • 3 mi"

### Visual Polish
- Reduced navigation bar height (`.inline` display mode)
- Smaller, more compact tab bar
- Commitment card stands out with subtle accent tint and border
- Tab bar extends properly to bottom safe area

## Files Changed
- `MainView.swift` - Custom tab bar integration, navigation changes
- `CustomTabBar.swift` - New custom tab bar component
- `TabBarButton.swift` - Reusable tab button component
- `CompactCommitmentCard.swift` - New compact card + full sheet + goal persistence
- `PlanView.swift` - Segmented control for Training/Research
- `TrainingView.swift` - Added WeeklyStatsCard, renamed to Progress
- `ActivitiesView.swift` - Uses CompactCommitmentCard, removed FAB

## Test Plan
- [ ] Tab navigation works for all 4 content tabs
- [ ] Record button opens PreRecordingView, returns to Activities on dismiss
- [ ] Setting commitment goes directly to activity picker
- [ ] Commitment sheet shows hero layout with change/remove options
- [ ] Setting a goal persists across app restarts (same day)
- [ ] Goals auto-clear the next day
- [ ] Goal displays on compact card when set
- [ ] Plan tab toggles between Training and Research sections

🤖 Generated with [Claude Code](https://claude.ai/code)